### PR TITLE
fix: sign workflow commits & add tools docs

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -11,9 +11,6 @@ on:
 
 jobs:
   sync-docs:
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     name: Sync docs to gitbook-docs repo
 


### PR DESCRIPTION
Closes: #45 

& fixes issue that initial commit in the remotely created PR were not signed