### PR TITLE
fix: remove token for gitbook-docs which is public in sync docs workflow

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -9,6 +9,10 @@ on:
       - "tools/*/README.md" # Only trigger when tools docs are changed
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+  
 jobs:
   sync-docs:
     runs-on: ubuntu-latest
@@ -67,7 +71,6 @@ jobs:
         with:
           path: gitbook-docs
           commit-message: "Update docs from ${{ env.REPO_NAME }} (commit: ${{ github.sha }})"
-          committer: "devops@taluslabs.xyz <devops@taluslabs.xyz>"
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           branch: docs-update-${{ env.REPO_NAME }}-${{ github.sha }}
           delete-branch: true

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  
+
 jobs:
   sync-docs:
     runs-on: ubuntu-latest
@@ -71,6 +71,7 @@ jobs:
         with:
           path: gitbook-docs
           commit-message: "Update docs from ${{ env.REPO_NAME }} (commit: ${{ github.sha }})"
+          committer: "devops@taluslabs.xyz <devops@taluslabs.xyz>"
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           branch: docs-update-${{ env.REPO_NAME }}-${{ github.sha }}
           delete-branch: true

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           repository: Talus-Network/gitbook-docs
           path: gitbook-docs
-          token: ${{ secrets.GH_ACCESS_TOKEN }} # Access Token with repo access
 
       - name: Sync documentation
         run: |
@@ -66,7 +65,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{secrets.GH_ACCESS_TOKEN}}
           path: gitbook-docs
           commit-message: "Update docs from ${{ env.REPO_NAME }} (commit: ${{ github.sha }})"
           committer: "devops@taluslabs.xyz <devops@taluslabs.xyz>"


### PR DESCRIPTION
## Notable changes

- see title

## References

- Closes: #130 

## Checklist

- [ ] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
