### PR TITLE
ci: replace archived actions-rs/toolchain with actions-rust-lang/setu…

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-docker-action@v4
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           profile: minimal
           toolchain: stable
@@ -76,7 +76,7 @@ jobs:
           path: ref-lcov
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           profile: minimal
           toolchain: stable


### PR DESCRIPTION
## Notable changes

Replace deprecated **actions-rs/toolchain@v1** [archived](https://github.com/actions-rs/toolchain) with maintained **actions-rust-lang/setup-rust-toolchain@v1** [latest v1.12.0, 2025-04-23](https://github.com/actions-rust-lang/setup-rust-toolchain/releases/tag/v1.12.0).


## References

[Reference](https://github.com/actions-rust-lang/setup-rust-toolchain/releases/tag/v1.12.0)

## Checklist

- [ ] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
