### PR TITLE
Update cargo-binstall GitHub Action to v1.12.5

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -40,7 +40,7 @@ jobs:
           shared-key: ${{ runner.os }}-cargo-pr-${{ github.event.pull_request.number }}
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.11.2
+        uses: cargo-bins/cargo-binstall@v1.12.5
 
       - name: Install cargo-llvm-cov
         run: cargo binstall cargo-llvm-cov --force
@@ -88,7 +88,7 @@ jobs:
           shared-key: ${{ runner.os }}-cargo-pr-${{ github.event.pull_request.number }}
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.11.2
+        uses: cargo-bins/cargo-binstall@v1.12.5
 
       - name: Install cargo-llvm-cov
         run: cargo binstall cargo-llvm-cov --force


### PR DESCRIPTION
## Notable changes

Upgraded the GitHub Action `cargo-bins/cargo-binstall` from v1.11.2 to the latest version v1.12.5.
This update includes the latest improvements and dependency updates provided by the maintainers.

## References

https://github.com/cargo-bins/cargo-binstall/releases/tag/v1.12.5

## Checklist

- [x] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
