### PR TITLE
Add exec command re-export

### DIFF
--- a/sdk/src/test_utils/containers.rs
+++ b/sdk/src/test_utils/containers.rs
@@ -12,6 +12,7 @@ use testcontainers_modules::{
 
 pub type SuiContainer = ContainerAsync<Sui>;
 pub type RedisContainer = ContainerAsync<Redis>;
+pub type ExecCommand = testcontainers_modules::testcontainers::core::ExecCommand;
 
 /// Spins up a Sui container and returns its handle and mapped RPC and faucet
 /// ports.


### PR DESCRIPTION
## Notable changes

- just re-exporting a type needed in leader

## References

- part of https://github.com/Talus-Network/nexus-next/issues/323
