### PR TITLE
fix: remove `license-file` from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.2.0-rc.7"
 repository = "https://github.com/Talus-Network/nexus-sdk"
 homepage = "https://talus.network"
 license = "Apache-2.0"
-license-file = "LICENSE"
 readme = "README.md"
 authors = ["Talus Engineers <engineering@taluslabs.xyz>"]
 keywords = ["blockchain", "cli", "framework", "nexus", "sdk", "sui", "talus"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,6 @@ version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-license-file.workspace = true
 readme.workspace = true
 authors.workspace = true
 keywords.workspace = true

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -7,7 +7,6 @@ version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-license-file.workspace = true
 readme.workspace = true
 authors.workspace = true
 keywords.workspace = true

--- a/toolkit-rust/Cargo.toml
+++ b/toolkit-rust/Cargo.toml
@@ -7,7 +7,6 @@ version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-license-file.workspace = true
 readme.workspace = true
 authors.workspace = true
 keywords.workspace = true

--- a/tools/llm-openai-chat-completion/Cargo.toml
+++ b/tools/llm-openai-chat-completion/Cargo.toml
@@ -7,7 +7,6 @@ version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-license-file.workspace = true
 readme.workspace = true
 authors.workspace = true
 keywords.workspace = true

--- a/tools/math/Cargo.toml
+++ b/tools/math/Cargo.toml
@@ -7,7 +7,6 @@ version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-license-file.workspace = true
 readme.workspace = true
 authors.workspace = true
 keywords.workspace = true

--- a/tools/social-twitter/Cargo.toml
+++ b/tools/social-twitter/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-license-file.workspace = true
 readme.workspace = true
 authors.workspace = true
 keywords.workspace = true

--- a/tools/storage-walrus/Cargo.toml
+++ b/tools/storage-walrus/Cargo.toml
@@ -7,7 +7,6 @@ version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
-license-file.workspace = true
 readme.workspace = true
 authors.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
This was causing warnings:

```
warning: nexus-sdk/sdk/Cargo.toml: only one of `license` or `license-file` is necessary
`license` should be used if the package license can be expressed with a standard SPDX expression.
`license-file` should be used if the package uses a non-standard license.
See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.
```
