### PR TITLE
fix(cli): fetch gas coin to fix crypto auth command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `create_wallet_context` takes `SUI_RPC_URL` into consideration when checking active env
 - when `nexus conf get` fails to parse the config it shows the error instead of defaulting
 - `master-key` uses keyring platform specific dependencies
+- `nexus crypto auth` fetches a new gas coin now
 
 ### `nexus-sdk`
 

--- a/cli/src/crypto/crypto_auth.rs
+++ b/cli/src/crypto/crypto_auth.rs
@@ -134,6 +134,8 @@ pub(crate) async fn crypto_auth(gas: GasArgs) -> AnyResult<(), NexusCliError> {
         }
     }
 
+    let gas_coin = fetch_gas_coin(&sui, address, gas.sui_gas_coin).await?;
+
     // Make borrow checker happy
     let objects = &get_nexus_objects(&mut conf).await?;
 


### PR DESCRIPTION
## Notable changes

- fetch gas coin again in crypto_auth to prevent "coin object not available for consumption" error during nexus crypto auth command.

## Checklist

- [x] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
