### PR TITLE
Reduce the size of error enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `nexus dag execute` now encrypts any `vertex.port` mentioned in the arguments
 - removed `--encrypt` flag in favour of storing the information in the JSON DAG definition
 - replaced all occurrences of `sap` with `tap`
+- reduce the size of some error enums
 
 #### Removed
 

--- a/cli/src/utils/secrets/master_key_provider.rs
+++ b/cli/src/utils/secrets/master_key_provider.rs
@@ -12,6 +12,6 @@ impl KeyProvider for MasterKeyProvider {
     type Key = Zeroizing<[u8; KEY_LEN]>;
 
     fn key(&self) -> Result<Self::Key, SecretStoreError> {
-        master_key::get_master_key().map_err(|e| SecretStoreError::Provider(e.to_string()))
+        master_key::get_master_key().map_err(|e| SecretStoreError::Provider(e.to_string().into()))
     }
 }

--- a/sdk/src/crypto/session.rs
+++ b/sdk/src/crypto/session.rs
@@ -86,7 +86,7 @@ pub enum SessionError {
     DecryptionFailed,
     /// Any attempt to use a session in an impossible state.
     #[error("Session state error: {0}")]
-    InvalidState(String),
+    InvalidState(Box<str>),
     /// Message claims an unsupported protocol version.
     #[error("Unsupported protocol version {0}")]
     Version(u8),

--- a/sdk/src/secret_core/error.rs
+++ b/sdk/src/secret_core/error.rs
@@ -8,9 +8,9 @@ pub enum SecretStoreError {
     #[error("base‑64 decode error: {0}")]
     Base64(#[from] base64::DecodeError),
     #[error("serialization codec error: {0}")]
-    Codec(String),
+    Codec(Box<str>),
     #[error("cryptography failure: {0}")]
     Crypto(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("provider failure: {0}")]
-    Provider(String),
+    Provider(Box<str>),
 }

--- a/sdk/src/secret_core/secret.rs
+++ b/sdk/src/secret_core/secret.rs
@@ -198,7 +198,8 @@ where
             let key = provider.key()?;
 
             let pt_bytes = A::decrypt_with_key(&key, &nonce, &ct)?;
-            let value = C::decode(&pt_bytes).map_err(|e| SecretStoreError::Codec(e.to_string()))?;
+            let value =
+                C::decode(&pt_bytes).map_err(|e| SecretStoreError::Codec(e.to_string().into()))?;
 
             self.plain = Some(value);
         }

--- a/sdk/src/secret_core/traits.rs
+++ b/sdk/src/secret_core/traits.rs
@@ -40,11 +40,11 @@ pub trait PlaintextCodec: Default + Send + Sync + 'static {
 pub struct BincodeCodec;
 impl PlaintextCodec for BincodeCodec {
     fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, SecretStoreError> {
-        bincode::serialize(value).map_err(|e| SecretStoreError::Codec(e.to_string()))
+        bincode::serialize(value).map_err(|e| SecretStoreError::Codec(e.to_string().into()))
     }
 
     fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, SecretStoreError> {
-        bincode::deserialize(bytes).map_err(|e| SecretStoreError::Codec(e.to_string()))
+        bincode::deserialize(bytes).map_err(|e| SecretStoreError::Codec(e.to_string().into()))
     }
 }
 

--- a/tools/social-twitter/src/media/upload_media.rs
+++ b/tools/social-twitter/src/media/upload_media.rs
@@ -204,10 +204,13 @@ async fn upload_media(
     // Validate number of chunks doesn't exceed Twitter's API limit of 999
     let total_chunks = media_data.len().div_ceil(optimal_chunk_size);
     if total_chunks > 999 {
-        return Err(TwitterError::Other(format!(
-            "Media would require {} chunks, which exceeds Twitter's limit of 999.",
-            total_chunks
-        )));
+        return Err(TwitterError::Other(
+            format!(
+                "Media would require {} chunks, which exceeds Twitter's limit of 999.",
+                total_chunks
+            )
+            .into(),
+        ));
     }
 
     // 1. INIT phase - Initialize upload
@@ -377,11 +380,12 @@ async fn init_upload(
         .await
         .map_err(|e| {
             TwitterError::ApiError(
-                e.reason,
-                format!("{:?}", e.kind),
+                e.reason.into(),
+                format!("{:?}", e.kind).into(),
                 e.status_code
                     .map(|code| code.to_string())
-                    .unwrap_or_default(),
+                    .unwrap_or_default()
+                    .into(),
             )
         })
 }
@@ -396,10 +400,13 @@ async fn append_chunk(
 ) -> TwitterResult<()> {
     // Validate segment_index is within allowed range (0-999)
     if !(0..=999).contains(&segment_index) {
-        return Err(TwitterError::Other(format!(
-            "Invalid segment_index: {}. Must be between 0 and 999",
-            segment_index
-        )));
+        return Err(TwitterError::Other(
+            format!(
+                "Invalid segment_index: {}. Must be between 0 and 999",
+                segment_index
+            )
+            .into(),
+        ));
     }
 
     // Create part for the media chunk
@@ -418,11 +425,12 @@ async fn append_chunk(
         .await
         .map_err(|e| {
             TwitterError::ApiError(
-                e.reason,
-                format!("{:?}", e.kind),
+                e.reason.into(),
+                format!("{:?}", e.kind).into(),
                 e.status_code
                     .map(|code| code.to_string())
-                    .unwrap_or_default(),
+                    .unwrap_or_default()
+                    .into(),
             )
         })
 }
@@ -443,11 +451,12 @@ async fn finalize_upload(
         .await
         .map_err(|e| {
             TwitterError::ApiError(
-                e.reason,
-                format!("{:?}", e.kind),
+                e.reason.into(),
+                format!("{:?}", e.kind).into(),
                 e.status_code
                     .map(|code| code.to_string())
-                    .unwrap_or_default(),
+                    .unwrap_or_default()
+                    .into(),
             )
         })
 }
@@ -474,15 +483,13 @@ async fn wait_for_processing_completion(
                 }
                 super::models::ProcessingState::Failed => {
                     // Processing failed
-                    return Err(TwitterError::Other("Media processing failed".to_string()));
+                    return Err(TwitterError::Other("Media processing failed".into()));
                 }
                 _ => {
                     // Still processing
                     attempts += 1;
                     if attempts >= MAX_ATTEMPTS {
-                        return Err(TwitterError::Other(
-                            "Media processing timed out".to_string(),
-                        ));
+                        return Err(TwitterError::Other("Media processing timed out".into()));
                     }
 
                     // Wait for the recommended time or default to 2 seconds
@@ -513,11 +520,12 @@ async fn check_media_status(
         .await
         .map_err(|e| {
             TwitterError::ApiError(
-                e.reason,
-                format!("{:?}", e.kind),
+                e.reason.into(),
+                format!("{:?}", e.kind).into(),
                 e.status_code
                     .map(|code| code.to_string())
-                    .unwrap_or_default(),
+                    .unwrap_or_default()
+                    .into(),
             )
         })
 }

--- a/tools/social-twitter/src/twitter_client.rs
+++ b/tools/social-twitter/src/twitter_client.rs
@@ -27,7 +27,7 @@ pub(crate) const TWITTER_X_API_BASE: &str = "https://api.x.com/2";
 #[derive(Debug, thiserror::Error)]
 pub enum TwitterClientError {
     #[error("Unsupported HTTP method: {0}")]
-    UnsupportedMethod(String),
+    UnsupportedMethod(Box<str>),
 }
 
 impl TwitterClient {
@@ -155,7 +155,9 @@ impl TwitterClient {
             "PUT" => auth.generate_auth_header_for_put(&self.api_base),
             _ => {
                 return Err(TwitterError::Other(
-                    TwitterClientError::UnsupportedMethod(method.to_string()).to_string(),
+                    TwitterClientError::UnsupportedMethod(method.into())
+                        .to_string()
+                        .into(),
                 )
                 .to_error_response())
             }


### PR DESCRIPTION
## Notable changes

A large enum used in several places can cause a negative runtime impact. In fact, this is so common that the community created several lints to prevent such a scenario.

- [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/?groups=perf#large_enum_variant)
- [result_large_err](https://rust-lang.github.io/rust-clippy/master/?groups=perf#result_large_err)
- [variant_size_differences](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/types/static.VARIANT_SIZE_DIFFERENCES.html)

This PR cuts 8~24 bytes from different error enums through the use of `Box<str>`, which doesn't change any intended behavior.

Of course, 8~24 bytes won't make much of a runtime different in this project but it is still worthwhile IMO. 

## Checklist

- [ ] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
