### PR TITLE
Add push and workflow_dispatch triggers

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -7,6 +7,15 @@ on:
       - sdk/**
       - toolkit-rust/**
       - tools/**
+  push:
+    branches:
+      - main
+    paths:
+      - cli/**
+      - sdk/**
+      - toolkit-rust/**
+      - tools/**
+  workflow_dispatch:
 
 # Fix for OOM.
 env:


### PR DESCRIPTION
## Notable changes

- Follow up to https://github.com/Talus-Network/nexus-sdk/pull/228
- We now need to run the coverage on main after merge, to get coverage percentage on the badge

## References

NA

## Checklist

- [ ] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
