### PR TITLE
Fix the `cli/` separation in codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,14 +17,6 @@ coverage:
         only_pulls: false
 
     patch:
-      default:
-        # New code should have at least 80% coverage
-        target: 80%
-        threshold: 10% # Allow 10% drop for edge cases
-        base: auto
-        if_ci_failed: error
-        informational: false
-
       cli:
         # CLI patch coverage is informational only
         target: 80%
@@ -33,7 +25,16 @@ coverage:
         if_ci_failed: error
         informational: true
         paths:
-          - cli/**
+          - "cli/"
+      default:
+        # New code should have at least 80% coverage
+        target: 80%
+        threshold: 10% # Allow 10% drop for edge cases
+        base: auto
+        if_ci_failed: error
+        informational: false
+        paths:
+          - "!cli/"
 
 component_management:
   individual_components:


### PR DESCRIPTION
Apparently, the separation between what is `cli` and what is not must be made explicit.

Ref: https://github.com/Talus-Network/nexus-sdk/pull/252
Ref: No ticket.

