### PR TITLE
Trigger audit dependencies action  on Pull request trigger

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,5 +1,6 @@
 name: Audit Dependencies
 on:
+  pull_request:
   push:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
## Notable changes

- Fixes issue, where audit dependencies action does not trigger on pull requests.

## References

N/A

## Checklist

- [ ] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
