### PR TITLE
docs: fix typo in "dependent"

### DIFF
--- a/docs/toolkit-rust.md
+++ b/docs/toolkit-rust.md
@@ -132,7 +132,7 @@ This defaults to the root route.
 
 Defines the Tool's health check. This is a simple function that returns a `anyhow::Result<warp::http::StatusCode>`. The Tool is considered healthy if this function returns `Ok(StatusCode::OK)`.
 
-The health check **should check for the health of dependant** services and return an error if they are not healthy.
+The health check **should check for the health of dependent** services and return an error if they are not healthy.
 
 ```rs
 use nexus_toolkit::*;


### PR DESCRIPTION
## Notable changes

- correct form is [dependent](https://www.merriam-webster.com/dictionary/dependent
- )
## References
## Checklist

- [ ] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [x] create or update documentation
