### PR TITLE
remove arch from setup guide

### DIFF
--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -23,14 +23,6 @@ brew tap talus-network/tap
 brew install nexus-cli
 ```
 
-#### Arch Linux
-
-The [nexus-cli](https://aur.archlinux.org/packages/nexus-cli) is also available in the AUR (Arch User Repository). You can install it using your preferred [AUR helper](https://wiki.archlinux.org/title/AUR_helpers):
-
-```bash
-yay -S nexus-cli
-```
-
 #### Using cargo-binstall (recommended for faster binaries)
 
 If you prefer quicker binary installation, use [cargo-binstall](https://github.com/cargo-bins/cargo-binstall):


### PR DESCRIPTION
## Notable changes

- Removes reference to arch, until we can push new version there

## References

- provide a list of tickets this PR resolves or references

## Checklist

- [ ] keep a changelog
- [ ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
