### PR TITLE
grpc: SDK types & events

### DIFF
--- a/sdk/src/events/fetching.rs
+++ b/sdk/src/events/fetching.rs
@@ -1,0 +1,282 @@
+//! This module wraps a Sui GQL endpoint to provide the functionality to fetch
+//! events. These are sent over a channel to the consumer. ALl events are parsed
+//! to [`NexusEvent`]. Those that cannot be parsed are ignored.
+//!
+//! Note that the polling will stop whenever the receiver side of the channel is
+//! dropped.
+
+use {
+    crate::{
+        events::{
+            graphql::events_query::{events_query, EventsQuery},
+            FromSuiGqlEvent,
+            NexusEvent,
+        },
+        idents::primitives,
+        types::NexusObjects,
+    },
+    graphql_client::{GraphQLQuery, Response},
+    reqwest::Client,
+    std::sync::Arc,
+};
+
+/// This struct defines the structure of the message sent over the channel.
+pub struct EventPage {
+    pub events: Vec<NexusEvent>,
+    pub next_cursor: String,
+}
+
+/// The fetcher struct itself. Responsible for creating a poller thread,
+/// fetching and parsing events and sending them over a channel.
+#[derive(Clone)]
+pub struct EventFetcher {
+    url: String,
+    channel_capacity: usize,
+    max_poll_interval: tokio::time::Duration,
+    nexus_objects: Arc<NexusObjects>,
+}
+
+impl EventFetcher {
+    /// Create a new EventFetcher instance pointing to the given graphql URL.
+    pub fn new(url: &str, nexus_objects: Arc<NexusObjects>) -> Self {
+        Self {
+            url: url.to_string(),
+            channel_capacity: 100,
+            max_poll_interval: tokio::time::Duration::from_secs(2),
+            nexus_objects,
+        }
+    }
+
+    /// Set the desired channel capacity.
+    pub fn with_channel_capacity(mut self, capacity: usize) -> Self {
+        self.channel_capacity = capacity;
+        self
+    }
+
+    /// Set the maximum polling interval.
+    pub fn with_max_poll_interval(mut self, interval: tokio::time::Duration) -> Self {
+        self.max_poll_interval = interval;
+        self
+    }
+
+    /// Start polling for events and sending them over the given channel. Return
+    /// the JoinHandle of the polling task as well as the channel receiver.
+    pub fn poll_nexus_events(
+        &self,
+        from_cursor: Option<String>,
+        from_checkpoint: Option<u64>,
+    ) -> (
+        tokio::task::JoinHandle<()>,
+        tokio::sync::mpsc::Receiver<EventPage>,
+    ) {
+        let (notify_about_events, next_page) =
+            tokio::sync::mpsc::channel::<EventPage>(self.channel_capacity);
+
+        let poller = {
+            let nexus_objects = self.nexus_objects.clone();
+            let url = self.url.clone();
+            let mut cursor = from_cursor;
+            let mut at_checkpoint = from_checkpoint;
+
+            // Polling intervals.
+            let mut poll_interval = tokio::time::Duration::from_millis(100);
+            let max_poll_interval = self.max_poll_interval;
+
+            // NOTE: that the poller process is infallible. RPC errors result
+            // in backoff and retry. Events that cannot be parsed are ignored.
+            tokio::spawn(async move {
+                let event_wrapper = format!(
+                    "{package}::{module}::{name}",
+                    package = nexus_objects.primitives_pkg_id,
+                    module = primitives::Event::EVENT_WRAPPER.module.as_str(),
+                    name = primitives::Event::EVENT_WRAPPER.name.as_str(),
+                );
+
+                loop {
+                    let request = events_query::Variables {
+                        after: cursor.clone(),
+                        at_checkpoint,
+                        filter: events_query::EventFilter {
+                            type_: Some(event_wrapper.clone()),
+                            sender: None,
+                            after_checkpoint: None,
+                            at_checkpoint: None,
+                            before_checkpoint: None,
+                            module: None,
+                        },
+                    };
+
+                    let query = EventsQuery::build_query(request);
+                    let client = Client::new();
+
+                    // Send the GQL request.
+                    let response = match client.post(&url).json(&query).send().await {
+                        Ok(resp) => resp,
+                        Err(_) => {
+                            tokio::time::sleep(poll_interval).await;
+
+                            poll_interval = std::cmp::min(poll_interval * 2, max_poll_interval);
+
+                            continue;
+                        }
+                    };
+
+                    // Parse the GQL response.
+                    let response: Response<events_query::ResponseData> = match response.json().await
+                    {
+                        Ok(data) => data,
+                        Err(_) => {
+                            tokio::time::sleep(poll_interval).await;
+
+                            poll_interval = std::cmp::min(poll_interval * 2, max_poll_interval);
+
+                            continue;
+                        }
+                    };
+
+                    // Parse the response data.
+                    let (events, page_info) = match response
+                        .data
+                        .and_then(|d| d.events)
+                        .map(|e| (e.nodes, e.page_info))
+                    {
+                        Some((events, page_info)) => (events, page_info),
+                        None => {
+                            tokio::time::sleep(poll_interval).await;
+
+                            poll_interval = std::cmp::min(poll_interval * 2, max_poll_interval);
+
+                            continue;
+                        }
+                    };
+
+                    // If there are no events, backoff.
+                    if events.is_empty() {
+                        tokio::time::sleep(poll_interval).await;
+
+                        poll_interval = std::cmp::min(poll_interval * 2, max_poll_interval);
+
+                        continue;
+                    }
+
+                    // `page_info.end_cursor` should always exist.
+                    let Some(next_cursor) = page_info.end_cursor.clone() else {
+                        continue;
+                    };
+
+                    let nexus_events = events.into_iter().filter_map(|event| {
+                        let index = event.sequence_number;
+                        let digest = event.transaction.and_then(|t| t.digest.parse().ok())?;
+                        let package_id = event.transaction_module?.package?.address;
+                        let contents = event.contents?;
+
+                        NexusEvent::from_sui_gql_event(
+                            index,
+                            digest,
+                            package_id,
+                            &contents,
+                            &nexus_objects,
+                        )
+                        .ok()
+                    });
+
+                    cursor = Some(next_cursor.clone());
+                    at_checkpoint = None;
+
+                    match notify_about_events
+                        .send(EventPage {
+                            events: nexus_events.collect(),
+                            next_cursor,
+                        })
+                        .await
+                    {
+                        Ok(()) => {
+                            poll_interval = tokio::time::Duration::from_millis(100);
+
+                            tokio::time::sleep(poll_interval).await;
+                        }
+                        Err(_) => {
+                            // Receiver dropped, exit the poller process.
+                            break;
+                        }
+                    }
+                }
+            })
+        };
+
+        (poller, next_page)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            events::{DAGCreatedEvent, NexusEventKind},
+            sui,
+            test_utils::sui_mocks,
+        },
+        mockito::Server,
+    };
+
+    #[tokio::test]
+    async fn test_event_fetcher_polling() {
+        let mut rng = rand::thread_rng();
+        let mut server = Server::new_async().await;
+        let objects = sui_mocks::mock_nexus_objects();
+        let primitives_pkg_id = objects.primitives_pkg_id;
+
+        let dag_id_1 = sui::types::Address::generate(&mut rng);
+        let dag_id_2 = sui::types::Address::generate(&mut rng);
+        let dag_id_3 = sui::types::Address::generate(&mut rng);
+        let events = vec![
+            NexusEventKind::DAGCreated(DAGCreatedEvent { dag: dag_id_1 }),
+            NexusEventKind::DAGCreated(DAGCreatedEvent { dag: dag_id_2 }),
+            NexusEventKind::DAGCreated(DAGCreatedEvent { dag: dag_id_3 }),
+        ];
+        let digest = sui::types::Digest::generate(&mut rng);
+
+        let mock = sui_mocks::gql::mock_event_query(
+            &mut server,
+            primitives_pkg_id,
+            events.clone(),
+            Some(digest),
+            Some("12345"),
+        );
+
+        let fetcher = EventFetcher::new(&format!("{}/graphql", &server.url()), Arc::new(objects));
+
+        let (_poller, mut receiver) = fetcher.poll_nexus_events(None, None);
+
+        if let Some(page) = receiver.recv().await {
+            assert_eq!(page.next_cursor, "12345".to_string());
+            assert_eq!(page.events.len(), 3);
+
+            let first_event = &page.events[0];
+            assert_eq!(first_event.id, (digest, 0));
+            assert!(matches!(
+                first_event.data,
+                NexusEventKind::DAGCreated(DAGCreatedEvent { dag }) if dag == dag_id_1
+            ));
+
+            let second_event = &page.events[1];
+            assert_eq!(second_event.id, (digest, 1));
+            assert!(matches!(
+                second_event.data,
+                NexusEventKind::DAGCreated(DAGCreatedEvent { dag }) if dag == dag_id_2
+            ));
+
+            let third_event = &page.events[2];
+            assert_eq!(third_event.id, (digest, 2));
+            assert!(matches!(
+                third_event.data,
+                NexusEventKind::DAGCreated(DAGCreatedEvent { dag }) if dag == dag_id_3
+            ));
+        } else {
+            panic!("Did not receive any events from the fetcher.");
+        }
+
+        mock.assert_async().await;
+    }
+}

--- a/sdk/src/events/graphql/events_query.graphql
+++ b/sdk/src/events/graphql/events_query.graphql
@@ -1,0 +1,33 @@
+query EventsQuery(
+  $after: String
+  $at_checkpoint: UInt53
+  $filter: EventFilter!
+) {
+  events(
+    first: 50
+    after: $after
+    atCheckpoint: $at_checkpoint
+    filter: $filter
+  ) {
+    nodes {
+      sequenceNumber
+      transaction {
+        digest
+      }
+      transactionModule {
+        package {
+          address
+        }
+      }
+      contents {
+        json
+        type {
+          repr
+        }
+      }
+    }
+    pageInfo {
+      endCursor
+    }
+  }
+}

--- a/sdk/src/events/graphql/events_query.rs
+++ b/sdk/src/events/graphql/events_query.rs
@@ -1,0 +1,14 @@
+use graphql_client::GraphQLQuery;
+
+type SuiAddress = sui_sdk_types::Address;
+type UInt53 = u64;
+#[allow(clippy::upper_case_acronyms)]
+type JSON = serde_json::Value;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/events/graphql/schema-1.61.2.graphql",
+    query_path = "src/events/graphql/events_query.graphql",
+    response_derives = "Debug"
+)]
+pub struct EventsQuery;

--- a/sdk/src/events/graphql/mod.rs
+++ b/sdk/src/events/graphql/mod.rs
@@ -1,0 +1,1 @@
+pub mod events_query;

--- a/sdk/src/events/graphql/schema-1.61.2.graphql
+++ b/sdk/src/events/graphql/schema-1.61.2.graphql
@@ -1,0 +1,5370 @@
+"""
+System transaction for creating the accumulator root.
+"""
+type AccumulatorRootCreateTransaction {
+  """
+  A workaround to define an empty variant of a GraphQL union.
+  """
+  _: Boolean
+}
+
+type ActiveJwk {
+  """
+  The string (Issuing Authority) that identifies the OIDC provider.
+  """
+  iss: String
+
+  """
+  The string (Key ID) that identifies the JWK among a set of JWKs, (RFC 7517, Section 4.5).
+  """
+  kid: String
+
+  """
+  The JWK key type parameter, (RFC 7517, Section 4.1).
+  """
+  kty: String
+
+  """
+  The JWK RSA public exponent, (RFC 7517, Section 9.3).
+  """
+  e: String
+
+  """
+  The JWK RSA modulus, (RFC 7517, Section 9.3).
+  """
+  n: String
+
+  """
+  The JWK algorithm parameter, (RFC 7517, Section 4.4).
+  """
+  alg: String
+
+  """
+  The most recent epoch in which the JWK was validated.
+  """
+  epoch: Epoch
+}
+
+type ActiveJwkConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [ActiveJwkEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [ActiveJwk!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ActiveJwkEdge {
+  """
+  The item at the end of the edge
+  """
+  node: ActiveJwk!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+type Address implements IAddressable {
+  """
+  The Address' identifier, a 32-byte number represented as a 64-character hex string, with a lead "0x".
+  """
+  address: SuiAddress!
+
+  """
+  Attempts to fetch the object at this address.
+  """
+  asObject: Object
+
+  """
+  Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+
+  Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+  If the address does not own any coins of that type, a balance of zero is returned.
+  """
+  balance(coinType: String!): Balance
+
+  """
+  Total balance across coins owned by this address, grouped by coin type.
+  """
+  balances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): BalanceConnection
+
+  """
+  The domain explicitly configured as the default SuiNS name for this address.
+  """
+  defaultSuinsName: String
+
+  """
+  Access a dynamic field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
+  """
+  dynamicField(name: DynamicFieldName!): DynamicField
+
+  """
+  Dynamic fields owned by this address.
+
+  The address must correspond to an object (account addresses cannot own dynamic fields), but that object may be wrapped.
+  """
+  dynamicFields(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): DynamicFieldConnection
+
+  """
+  Access a dynamic object field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic object field with that name could not be found attached to the object with this address.
+  """
+  dynamicObjectField(name: DynamicFieldName!): DynamicField
+
+  """
+  Access dynamic fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  Access dynamic object fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+
+  Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+  If the address does not own any coins of a given type, a balance of zero is returned for that type.
+  """
+  multiGetBalances(keys: [String!]!): [Balance!]
+
+  """
+  Objects owned by this address, optionally filtered by type.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: ObjectFilter
+  ): MoveObjectConnection
+
+  """
+  Transactions associated with this address.
+
+  Similar behavior to the `transactions` in Query but supporting the additional `AddressTransactionRelationship` filter, which defaults to `SENT`.
+  """
+  transactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    relation: AddressTransactionRelationship
+    filter: TransactionFilter
+  ): TransactionConnection
+}
+
+"""
+Object is exclusively owned by a single address, and is mutable.
+"""
+type AddressOwner {
+  """
+  The owner's address.
+  """
+  address: Address
+}
+
+"""
+The possible relationship types for a transaction: sent or affected.
+"""
+enum AddressTransactionRelationship {
+  """
+  Transactions this address has sent.
+  """
+  SENT
+
+  """
+  Transactions that this address was involved in, either as the sender, sponsor, or as the owner of some object that was created, modified or transferred.
+  """
+  AFFECTED
+}
+
+"""
+System transaction for creating the on-chain state used by zkLogin.
+"""
+type AuthenticatorStateCreateTransaction {
+  """
+  A workaround to define an empty variant of a GraphQL union.
+  """
+  _: Boolean
+}
+
+"""
+System transaction that is executed at the end of an epoch to expire JSON Web Keys (JWKs) that are no longer valid, based on their associated epoch. This is part of the on-chain state management for zkLogin and authentication.
+"""
+type AuthenticatorStateExpireTransaction {
+  """
+  Expire JWKs that have a lower epoch than this.
+  """
+  minEpoch: Epoch
+
+  """
+  The initial version that the AuthenticatorStateUpdate was shared at.
+  """
+  authenticatorObjInitialSharedVersion: UInt53
+}
+
+type AuthenticatorStateUpdateTransaction {
+  """
+  Epoch of the authenticator state update transaction.
+  """
+  epoch: Epoch
+
+  """
+  Consensus round of the authenticator state update.
+  """
+  round: UInt53
+
+  """
+  Newly active JWKs (JSON Web Keys).
+  """
+  newActiveJwks(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): ActiveJwkConnection
+
+  """
+  The initial version of the authenticator object that it was shared at.
+  """
+  authenticatorObjInitialSharedVersion: UInt53
+}
+
+"""
+Checkpoint range for which data is available.
+"""
+type AvailableRange {
+  """
+  Inclusive lower checkpoint for which data is available.
+  """
+  first: Checkpoint
+
+  """
+  Inclusive upper checkpoint for which data is available.
+  """
+  last: Checkpoint
+}
+
+"""
+The total balance for a particular coin type.
+"""
+type Balance {
+  """
+  Coin type for the balance, such as `0x2::sui::SUI`.
+  """
+  coinType: MoveType
+
+  """
+  The total balance across all coin objects of this coin type.
+  """
+  totalBalance: BigInt
+}
+
+"""
+Effects to the balance (sum of coin values per coin type) of addresses and objects.
+"""
+type BalanceChange {
+  """
+  The address or object whose balance has changed.
+  """
+  owner: Address
+
+  """
+  The inner type of the coin whose balance has changed (e.g. `0x2::sui::SUI`).
+  """
+  coinType: MoveType
+
+  """
+  The signed balance change.
+  """
+  amount: BigInt
+}
+
+type BalanceChangeConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [BalanceChangeEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [BalanceChange!]!
+}
+
+"""
+An edge in a connection.
+"""
+type BalanceChangeEdge {
+  """
+  The item at the end of the edge
+  """
+  node: BalanceChange!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+type BalanceConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [BalanceEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [Balance!]!
+}
+
+"""
+An edge in a connection.
+"""
+type BalanceEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Balance!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+String containing Base64-encoded binary data.
+"""
+scalar Base64
+
+"""
+String representation of an arbitrary width, possibly signed integer
+"""
+scalar BigInt
+
+"""
+System transaction for initializing bridge committee.
+"""
+type BridgeCommitteeInitTransaction {
+  """
+  The initial shared version of the bridge object.
+  """
+  bridgeObjectVersion: UInt53
+}
+
+"""
+System transaction for creating bridge state for cross-chain operations.
+"""
+type BridgeStateCreateTransaction {
+  """
+  The chain identifier for which this bridge state is being created.
+  """
+  chainIdentifier: String
+}
+
+"""
+A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
+
+This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
+"""
+type ChangeEpochTransaction {
+  """
+  The next (to become) epoch.
+  """
+  epoch: Epoch
+
+  """
+  The epoch's corresponding protocol configuration.
+  """
+  protocolConfigs: ProtocolConfigs
+
+  """
+  The total amount of gas charged for storage during the epoch.
+  """
+  storageCharge: UInt53
+
+  """
+  The total amount of gas charged for computation during the epoch.
+  """
+  computationCharge: UInt53
+
+  """
+  The amount of storage rebate refunded to the transaction senders.
+  """
+  storageRebate: UInt53
+
+  """
+  The non-refundable storage fee.
+  """
+  nonRefundableStorageFee: UInt53
+
+  """
+  Unix timestamp when epoch started.
+  """
+  epochStartTimestamp: DateTime
+
+  """
+  System packages that will be written by validators before the new epoch starts, to upgrade them on-chain. These objects do not have a "previous transaction" because they are not written on-chain yet. Consult `effects.objectChanges` for this transaction to see the actual objects written.
+  """
+  systemPackages(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): MovePackageConnection
+}
+
+"""
+Checkpoints contain finalized transactions and are used for node synchronization and global transaction ordering.
+"""
+type Checkpoint {
+  """
+  The checkpoint's position in the total order of finalized checkpoints, agreed upon by consensus.
+  """
+  sequenceNumber: UInt53!
+
+  """
+  Query the RPC as if this checkpoint were the latest checkpoint.
+  """
+  query: Query
+
+  """
+  A commitment by the committee at each checkpoint on the artifacts of the checkpoint.
+  e.g., object checkpoint states
+  """
+  artifactsDigest: String
+
+  """
+  A 32-byte hash that uniquely identifies the checkpoint, encoded in Base58. This is a hash of the checkpoint's summary.
+  """
+  digest: String
+
+  """
+  A 32-byte hash that uniquely identifies the checkpoint's content, encoded in Base58.
+  """
+  contentDigest: String
+
+  """
+  The epoch that this checkpoint is part of.
+  """
+  epoch: Epoch
+
+  """
+  The total number of transactions in the network by the end of this checkpoint.
+  """
+  networkTotalTransactions: UInt53
+
+  """
+  The digest of the previous checkpoint's summary.
+  """
+  previousCheckpointDigest: String
+
+  """
+  The computation cost, storage cost, storage rebate, and non-refundable storage fee accumulated during this epoch, up to and including this checkpoint. These values increase monotonically across checkpoints in the same epoch, and reset on epoch boundaries.
+  """
+  rollingGasSummary: GasCostSummary
+
+  """
+  The Base64 serialized BCS bytes of this checkpoint's summary.
+  """
+  summaryBcs: Base64
+
+  """
+  The Base64 serialized BCS bytes of this checkpoint's contents.
+  """
+  contentBcs: Base64
+
+  """
+  The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
+  """
+  timestamp: DateTime
+
+  """
+  The aggregation of signatures from a quorum of validators for the checkpoint proposal.
+  """
+  validatorSignatures: ValidatorAggregatedSignature
+  transactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: TransactionFilter
+  ): TransactionConnection
+}
+
+type CheckpointConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [CheckpointEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [Checkpoint!]!
+}
+
+"""
+An edge in a connection.
+"""
+type CheckpointEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Checkpoint!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+input CheckpointFilter {
+  """
+  Limit query results to checkpoints at this epoch.
+  """
+  atEpoch: UInt53
+
+  """
+  Limit query results to checkpoints that occured strictly after the given checkpoint.
+  """
+  afterCheckpoint: UInt53
+
+  """
+  Limit query results to checkpoints that occured at the given checkpoint.
+  """
+  atCheckpoint: UInt53
+
+  """
+  Limit query results to checkpoints that occured strictly before the given checkpoint.
+  """
+  beforeCheckpoint: UInt53
+}
+
+"""
+System transaction for creating the coin deny list state.
+"""
+type CoinDenyListStateCreateTransaction {
+  """
+  A workaround to define an empty variant of a GraphQL union.
+  """
+  _: Boolean
+}
+
+"""
+An object representing metadata about a coin type.
+"""
+type CoinMetadata implements IAddressable & IMoveObject & IObject {
+  """
+  The CoinMetadata's ID.
+  """
+  address: SuiAddress!
+
+  """
+  The version of this object that this content comes from.
+  """
+  version: UInt53
+
+  """
+  32-byte hash that identifies the object's contents, encoded in Base58.
+  """
+  digest: String
+
+  """
+  Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+
+  If the address does not own any coins of that type, a balance of zero is returned.
+  """
+  balance(coinType: String!): Balance
+
+  """
+  Total balance across coins owned by this address, grouped by coin type.
+  """
+  balances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): BalanceConnection
+
+  """
+  The structured representation of the object's contents.
+  """
+  contents: MoveValue
+
+  """
+  Number of decimal places the coin uses.
+  """
+  decimals: Int
+
+  """
+  The domain explicitly configured as the default SuiNS name for this address.
+  """
+  defaultSuinsName: String
+
+  """
+  Description of the coin.
+  """
+  description: String
+
+  """
+  Access a dynamic field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic field with that name could not be found attached to this object.
+  """
+  dynamicField(name: DynamicFieldName!): DynamicField
+
+  """
+  Dynamic fields owned by this object.
+
+  Dynamic fields on wrapped objects can be accessed using `Address.dynamicFields`.
+  """
+  dynamicFields(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): DynamicFieldConnection
+
+  """
+  Access a dynamic object field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic object field with that name could not be found attached to this object.
+  """
+  dynamicObjectField(name: DynamicFieldName!): DynamicField
+
+  """
+  Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+
+  Both these operations require the object to have both the `key` and `store` abilities.
+  """
+  hasPublicTransfer: Boolean
+
+  """
+  URL for the coin logo.
+  """
+  iconUrl: String
+
+  """
+  Access dynamic fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  Access dynamic object fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  The Base64-encoded BCS serialize of this object, as a `MoveObject`.
+  """
+  moveObjectBcs: Base64
+
+  """
+  Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+
+  If the address does not own any coins of a given type, a balance of zero is returned for that type.
+  """
+  multiGetBalances(keys: [String!]!): [Balance!]
+
+  """
+  Name for the coin.
+  """
+  name: String
+
+  """
+  Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
+  """
+  objectAt(version: UInt53, rootVersion: UInt53, checkpoint: UInt53): Object
+
+  """
+  The Base64-encoded BCS serialization of this object, as an `Object`.
+  """
+  objectBcs: Base64
+
+  """
+  Paginate all versions of this object after this one.
+  """
+  objectVersionsAfter(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Paginate all versions of this object before this one.
+  """
+  objectVersionsBefore(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Objects owned by this object, optionally filtered by type.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: ObjectFilter
+  ): MoveObjectConnection
+
+  """
+  The object's owner kind.
+  """
+  owner: Owner
+
+  """
+  The transaction that created this version of the object.
+  """
+  previousTransaction: Transaction
+
+  """
+  The SUI returned to the sponsor or sender of the transaction that modifies or deletes this object.
+  """
+  storageRebate: BigInt
+
+  """
+  The transactions that sent objects to this object.
+  """
+  receivedTransactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: TransactionFilter
+  ): TransactionConnection
+
+  """
+  Whether the currency is regulated or not. `null` indicates that the regulatory status is unknown.
+  """
+  regulatedState: RegulatedState
+
+  """
+  Whether the `DenyCap` can be used to enable a global pause that behaves as if all addresses were added to the deny list. `null` indicates that it is not known whether the currency can be paused or not. This field is only populated on currencies held in the Coin Registry. To determine whether a legacy currency can be paused, check the contents of its `DenyCap`, if it can be found.
+  """
+  allowGlobalPause: Boolean
+
+  """
+  If the currency is regulated, this object represents the capability to modify the deny list. If a capability is known but wrapped, its address can be fetched but other fields will not be accessible.
+  """
+  denyCap: MoveObject
+
+  """
+  Future behavior of the supply. `null` indicates that the future behavior of the supply is not known because the currency's treasury still exists.
+  """
+  supplyState: SupplyState
+
+  """
+  The overall balance of coins issued.
+  """
+  supply: BigInt
+
+  """
+  Symbol for the coin.
+  """
+  symbol: String
+}
+
+"""
+System transaction for creating the coin registry.
+"""
+type CoinRegistryCreateTransaction {
+  """
+  A workaround to define an empty variant of a GraphQL union.
+  """
+  _: Boolean
+}
+
+"""
+A single command in the programmable transaction.
+"""
+union Command =
+    MakeMoveVecCommand
+  | MergeCoinsCommand
+  | MoveCallCommand
+  | PublishCommand
+  | SplitCoinsCommand
+  | TransferObjectsCommand
+  | UpgradeCommand
+  | OtherCommand
+
+type CommandConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [CommandEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [Command!]!
+}
+
+"""
+An edge in a connection.
+"""
+type CommandEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Command!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A value produced or modified during command execution.
+
+This can represent either a return value from a command or an argument that was mutated by reference.
+"""
+type CommandOutput {
+  """
+  The transaction argument that this value corresponds to (if any).
+  """
+  argument: TransactionArgument
+
+  """
+  The structured Move value, if available.
+  """
+  value: MoveValue
+}
+
+"""
+The intermediate results for each command of a transaction simulation.
+"""
+type CommandResult {
+  """
+  Return results of each command in this transaction.
+  """
+  returnValues: [CommandOutput!]
+
+  """
+  Changes made to arguments that were mutably borrowed by each command in this transaction.
+  """
+  mutatedReferences: [CommandOutput!]
+}
+
+"""
+Object is exclusively owned by a single adderss and sequenced via consensus.
+"""
+type ConsensusAddressOwner {
+  """
+  The version at which the object most recently bcame a consensus object. This serves the same function as `Shared.initialSharedVersion`, except it may change if the object's `owner` type changes.
+  """
+  startVersion: UInt53
+
+  """
+  The owner's address.
+  """
+  address: Address
+}
+
+"""
+System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
+"""
+type ConsensusCommitPrologueTransaction {
+  """
+  Epoch of the commit prologue transaction.
+
+  Present in V1, V2, V3, V4.
+  """
+  epoch: Epoch
+
+  """
+  Consensus round of the commit.
+
+  Present in V1, V2, V3, V4.
+  """
+  round: UInt53
+
+  """
+  Unix timestamp from consensus.
+
+  Present in V1, V2, V3, V4.
+  """
+  commitTimestamp: DateTime
+
+  """
+  Digest of consensus output, encoded as a Base58 string.
+
+  Present in V2, V3, V4.
+  """
+  consensusCommitDigest: String
+
+  """
+  The sub DAG index of the consensus commit. This field is populated if there
+  are multiple consensus commits per round.
+
+  Present in V3, V4.
+  """
+  subDagIndex: UInt53
+
+  """
+  Digest of any additional state computed by the consensus handler.
+  Used to detect forking bugs as early as possible.
+
+  Present in V4.
+  """
+  additionalStateDigest: String
+}
+
+"""
+Reason why a transaction that attempted to access a consensus-managed object was cancelled.
+"""
+enum ConsensusObjectCancellationReason {
+  """
+  Read operation was cancelled.
+  """
+  CANCELLED_READ
+
+  """
+  Object congestion prevented execution.
+  """
+  CONGESTED
+
+  """
+  Randomness service was unavailable.
+  """
+  RANDOMNESS_UNAVAILABLE
+
+  """
+  Internal use only.
+  """
+  UNKNOWN
+}
+
+"""
+A transaction that was cancelled before it could access the consensus-managed object, so the object was an input but remained unchanged.
+"""
+type ConsensusObjectCancelled {
+  """
+  The ID of the consensus-managed object that the transaction intended to access.
+  """
+  address: SuiAddress
+
+  """
+  Reason why the transaction was cancelled.
+  """
+  cancellationReason: ConsensusObjectCancellationReason
+}
+
+type ConsensusObjectRead {
+  """
+  The version of the consensus-managed object that was read by this transaction.
+  """
+  object: Object
+}
+
+"""
+ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. Note that the milliseconds part is optional, and it may be omitted if its value is 0.
+"""
+scalar DateTime
+
+"""
+A rendered JSON blob based on an on-chain template.
+"""
+type Display {
+  """
+  Output for all successfully substituted display fields. Unsuccessful fields will be `null`, and will be accompanied by a field in `errors`, explaining the error.
+  """
+  output: JSON
+
+  """
+  If any fields failed to render, this will contain a mapping from failed field names to error messages. If all fields succeed, this will be `null`.
+  """
+  errors: JSON
+}
+
+"""
+System transaction for creating the display registry.
+"""
+type DisplayRegistryCreateTransaction {
+  """
+  A workaround to define an empty variant of a GraphQL union.
+  """
+  _: Boolean
+}
+
+"""
+Dynamic fields are heterogenous fields that can be added or removed from an object at runtime. Their names are arbitrary Move values that have `copy`, `drop`, and `store`.
+
+There are two sub-types of dynamic fields:
+
+- Dynamic fields can store any value that has `store`. Objects stored in this kind of field will be considered wrapped (not accessible via its ID by external tools like explorers, wallets, etc. accessing storage).
+- Dynamic object fields can only store objects (values that have the `key` ability, and an `id: UID` as its first field) that have `store`, but they will still be directly accessible off-chain via their ID after being attached as a field.
+"""
+type DynamicField implements IAddressable & IMoveObject & IObject {
+  """
+  The DynamicField's ID.
+  """
+  address: SuiAddress!
+
+  """
+  The version of this object that this content comes from.
+  """
+  version: UInt53
+
+  """
+  32-byte hash that identifies the object's contents, encoded in Base58.
+  """
+  digest: String
+
+  """
+  Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+
+  If the address does not own any coins of that type, a balance of zero is returned.
+  """
+  balance(coinType: String!): Balance
+
+  """
+  Total balance across coins owned by this address, grouped by coin type.
+  """
+  balances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): BalanceConnection
+
+  """
+  The structured representation of the object's contents.
+  """
+  contents: MoveValue
+
+  """
+  The domain explicitly configured as the default SuiNS name for this address.
+  """
+  defaultSuinsName: String
+
+  """
+  Access a dynamic field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic field with that name could not be found attached to this object.
+  """
+  dynamicField(name: DynamicFieldName!): DynamicField
+
+  """
+  Dynamic fields owned by this object.
+
+  Dynamic fields on wrapped objects can be accessed using `Address.dynamicFields`.
+  """
+  dynamicFields(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): DynamicFieldConnection
+
+  """
+  Access a dynamic object field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic object field with that name could not be found attached to this object.
+  """
+  dynamicObjectField(name: DynamicFieldName!): DynamicField
+
+  """
+  Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+
+  Both these operations require the object to have both the `key` and `store` abilities.
+  """
+  hasPublicTransfer: Boolean
+
+  """
+  Access dynamic fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  Access dynamic object fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  The Base64-encoded BCS serialize of this object, as a `MoveObject`.
+  """
+  moveObjectBcs: Base64
+
+  """
+  Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+
+  If the address does not own any coins of a given type, a balance of zero is returned for that type.
+  """
+  multiGetBalances(keys: [String!]!): [Balance!]
+
+  """
+  The dynamic field's name, as a Move value.
+  """
+  name: MoveValue
+
+  """
+  Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
+  """
+  objectAt(version: UInt53, rootVersion: UInt53, checkpoint: UInt53): Object
+
+  """
+  The Base64-encoded BCS serialization of this object, as an `Object`.
+  """
+  objectBcs: Base64
+
+  """
+  Paginate all versions of this object after this one.
+  """
+  objectVersionsAfter(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Paginate all versions of this object before this one.
+  """
+  objectVersionsBefore(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Objects owned by this object, optionally filtered by type.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: ObjectFilter
+  ): MoveObjectConnection
+
+  """
+  The object's owner kind.
+  """
+  owner: Owner
+
+  """
+  The transaction that created this version of the object.
+  """
+  previousTransaction: Transaction
+
+  """
+  The SUI returned to the sponsor or sender of the transaction that modifies or deletes this object.
+  """
+  storageRebate: BigInt
+
+  """
+  The transactions that sent objects to this object.
+  """
+  receivedTransactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: TransactionFilter
+  ): TransactionConnection
+
+  """
+  The dynamic field's value, as a Move value for dynamic fields and as a MoveObject for dynamic object fields.
+  """
+  value: DynamicFieldValue
+}
+
+type DynamicFieldConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [DynamicFieldEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [DynamicField!]!
+}
+
+"""
+An edge in a connection.
+"""
+type DynamicFieldEdge {
+  """
+  The item at the end of the edge
+  """
+  node: DynamicField!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A description of a dynamic field's name.
+"""
+input DynamicFieldName {
+  """
+  The type of the dynamic field's name, like 'u64' or '0x2::kiosk::Listing'.
+  """
+  type: String!
+
+  """
+  The Base64-encoded BCS serialization of the dynamic field's 'name'.
+  """
+  bcs: Base64!
+}
+
+"""
+The value of a dynamic field (`MoveValue`) or dynamic object field (`MoveObject`).
+"""
+union DynamicFieldValue = MoveObject | MoveValue
+
+"""
+System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+"""
+type EndOfEpochTransaction {
+  """
+  The list of system transactions that are allowed to run at the end of the epoch.
+  """
+  transactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): EndOfEpochTransactionKindConnection
+}
+
+union EndOfEpochTransactionKind =
+    ChangeEpochTransaction
+  | AuthenticatorStateCreateTransaction
+  | AuthenticatorStateExpireTransaction
+  | RandomnessStateCreateTransaction
+  | CoinDenyListStateCreateTransaction
+  | StoreExecutionTimeObservationsTransaction
+  | BridgeStateCreateTransaction
+  | BridgeCommitteeInitTransaction
+  | AccumulatorRootCreateTransaction
+  | CoinRegistryCreateTransaction
+  | DisplayRegistryCreateTransaction
+
+type EndOfEpochTransactionKindConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [EndOfEpochTransactionKindEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+  """
+  The item at the end of the edge
+  """
+  node: EndOfEpochTransactionKind!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+Activity on Sui is partitioned in time, into epochs.
+
+Epoch changes are opportunities for the network to reconfigure itself (perform protocol or system package upgrades, or change the committee) and distribute staking rewards. The network aims to keep epochs roughly the same duration as each other.
+
+During a particular epoch the following data is fixed:
+
+- protocol version,
+- reference gas price,
+- system package versions,
+- validators in the committee.
+"""
+type Epoch {
+  """
+  The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
+  """
+  epochId: UInt53!
+
+  """
+  The epoch's corresponding checkpoints.
+  """
+  checkpoints(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: CheckpointFilter
+  ): CheckpointConnection
+
+  """
+  State of the Coin DenyList object (0x403) at the start of this epoch.
+
+  The DenyList controls access to Regulated Coins. Writes to the DenyList are accumulated and only take effect on the next epoch boundary. Consequently, it's possible to determine the state of the DenyList for a transaction by reading it at the start of the epoch the transaction is in.
+  """
+  coinDenyList: Object
+
+  """
+  The epoch's corresponding protocol configuration, including the feature flags and the configuration options.
+  """
+  protocolConfigs: ProtocolConfigs
+
+  """
+  The minimum gas price that a quorum of validators are guaranteed to sign a transaction for in this epoch.
+  """
+  referenceGasPrice: BigInt
+
+  """
+  The timestamp associated with the first checkpoint in the epoch.
+  """
+  startTimestamp: DateTime
+
+  """
+  The transactions in this epoch, optionally filtered by transaction filters.
+
+  Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+  """
+  transactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: TransactionFilter
+  ): TransactionConnection
+
+  """
+  The system packages used by all transactions in this epoch.
+  """
+  systemPackages(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): MovePackageConnection
+
+  """
+  The timestamp associated with the last checkpoint in the epoch (or `null` if the epoch has not finished yet).
+  """
+  endTimestamp: DateTime
+
+  """
+  Validator-related properties, including the active validators.
+  """
+  validatorSet: ValidatorSet
+
+  """
+  The total number of checkpoints in this epoch.
+
+  Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+  """
+  totalCheckpoints: UInt53
+
+  """
+  The total number of transaction blocks in this epoch (or `null` if the epoch has not finished yet).
+  """
+  totalTransactions: UInt53
+
+  """
+  The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
+  """
+  totalGasFees: BigInt
+
+  """
+  The total MIST rewarded as stake (or `null` if the epoch has not finished yet).
+  """
+  totalStakeRewards: BigInt
+
+  """
+  The amount added to total gas fees to make up the total stake rewards (or `null` if the epoch has not finished yet).
+  """
+  totalStakeSubsidies: BigInt
+
+  """
+  The storage fund available in this epoch (or `null` if the epoch has not finished yet).
+  This fund is used to redistribute storage fees from past transactions to future validators.
+  """
+  fundSize: BigInt
+
+  """
+  The difference between the fund inflow and outflow, representing the net amount of storage fees accumulated in this epoch (or `null` if the epoch has not finished yet).
+  """
+  netInflow: BigInt
+
+  """
+  The storage fees paid for transactions executed during the epoch (or `null` if the epoch has not finished yet).
+  """
+  fundInflow: BigInt
+
+  """
+  The storage fee rebates paid to users who deleted the data associated with past transactions (or `null` if the epoch has not finished yet).
+  """
+  fundOutflow: BigInt
+
+  """
+  SUI set aside to account for objects stored on-chain, at the start of the epoch.
+  This is also used for storage rebates.
+  """
+  storageFund: StorageFund
+
+  """
+  Information about whether this epoch was started in safe mode, which happens if the full epoch change logic fails.
+  """
+  safeMode: SafeMode
+
+  """
+  The value of the `version` field of `0x5`, the `0x3::sui::SuiSystemState` object.
+  This version changes whenever the fields contained in the system state object (held in a dynamic field attached to `0x5`) change.
+  """
+  systemStateVersion: UInt53
+
+  """
+  Details of the system that are decided during genesis.
+  """
+  systemParameters: SystemParameters
+
+  """
+  Parameters related to the subsidy that supplements staking rewards
+  """
+  systemStakeSubsidy: StakeSubsidy
+
+  """
+  A commitment by the committee at the end of epoch on the contents of the live object set at that time.
+  This can be used to verify state snapshots.
+  """
+  liveObjectSetDigest: String
+}
+
+type EpochConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [EpochEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [Epoch!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EpochEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Epoch!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+type Event {
+  """
+  The Move value emitted for this event.
+  """
+  contents: MoveValue
+
+  """
+  The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
+  This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
+  """
+  eventBcs: Base64
+
+  """
+  Address of the sender of the transaction that emitted this event.
+  """
+  sender: Address
+
+  """
+  The position of the event among the events from the same transaction.
+  """
+  sequenceNumber: UInt53!
+
+  """
+  Timestamp corresponding to the checkpoint this event's transaction was finalized in.
+  All events from the same transaction share the same timestamp.
+  """
+  timestamp: DateTime
+
+  """
+  The transaction that emitted this event. This information is only available for events from indexed transactions, and not from transactions that have just been executed or dry-run.
+  """
+  transaction: Transaction
+
+  """
+  The module containing the function that was called in the programmable transaction, that resulted in this event being emitted.
+  """
+  transactionModule: MoveModule
+}
+
+type EventConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [EventEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [Event!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EventEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Event!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+input EventFilter {
+  """
+  Limit to events that occured strictly after the given checkpoint.
+  """
+  afterCheckpoint: UInt53
+
+  """
+  Limit to events in the given checkpoint.
+  """
+  atCheckpoint: UInt53
+
+  """
+  Limit to event that occured strictly before the given checkpoint.
+  """
+  beforeCheckpoint: UInt53
+
+  """
+  Filter on events by transaction sender address.
+  """
+  sender: SuiAddress
+
+  """
+  Events emitted by a particular module. An event is emitted by a particular module if some function in the module is called by a PTB and emits an event.
+
+  Modules can be filtered by their package, or package::module. We currently do not support filtering by emitting module and event type at the same time so if both are provided in one filter, the query will error.
+  """
+  module: String
+
+  """
+  This field is used to specify the type of event emitted.
+
+  Events can be filtered by their type's package, package::module, or their fully qualified type name.
+
+  Generic types can be queried by either the generic type name, e.g. `0x2::coin::Coin`, or by the full type name, such as `0x2::coin::Coin<0x2::sui::SUI>`.
+  """
+  type: String
+}
+
+"""
+Represents execution error information for failed transactions.
+"""
+type ExecutionError {
+  """
+  The error code of the Move abort, populated if this transaction failed with a Move abort.
+
+  Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
+  """
+  abortCode: BigInt
+
+  """
+  The source line number for the abort. Only populated for clever errors.
+  """
+  sourceLineNumber: Int
+
+  """
+  The instruction offset in the Move bytecode where the error occurred. Populated for Move aborts and primitive runtime errors.
+  """
+  instructionOffset: Int
+
+  """
+  The error's name. Only populated for clever errors.
+  """
+  identifier: String
+
+  """
+  An associated constant for the error. Only populated for clever errors.
+
+  Constants are returned as human-readable strings when possible. Complex types are returned as Base64-encoded bytes.
+  """
+  constant: String
+
+  """
+  The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
+  """
+  module: MoveModule
+
+  """
+  The function that the abort originated from. Only populated for Move aborts and primitive runtime errors that have function name information.
+  """
+  function: MoveFunction
+
+  """
+  Human readable explanation of why the transaction failed.
+
+  For Move aborts, the error message will be resolved to a human-readable form if possible, otherwise it will fall back to displaying the abort code and location.
+  """
+  message: String!
+}
+
+"""
+The execution result of a transaction, including the transaction effects and any potential errors due to signing or quorum-driving.
+"""
+type ExecutionResult {
+  """
+  The effects of the transaction execution, if successful.
+  """
+  effects: TransactionEffects
+
+  """
+  Errors that occurred during execution (e.g., network errors, validation failures).
+  These are distinct from execution failures within the transaction itself.
+  """
+  errors: [String!]
+}
+
+"""
+The execution status of this transaction: success or failure.
+"""
+enum ExecutionStatus {
+  """
+  The transaction was successfully executed.
+  """
+  SUCCESS
+
+  """
+  The transaction could not be executed.
+  """
+  FAILURE
+}
+
+"""
+A boolean protocol configuration.
+"""
+type FeatureFlag {
+  """
+  Feature flag name.
+  """
+  key: String!
+
+  """
+  Feature flag value.
+  """
+  value: Boolean!
+}
+
+"""
+Access to the gas inputs, after they have been smashed into one coin. The gas coin can only be used by reference, except for with `TransferObjectsTransaction` that can accept it by value.
+"""
+type GasCoin {
+  """
+  Placeholder field (gas coin has no additional data)
+  """
+  _: Boolean
+}
+
+"""
+Summary of charges from transactions.
+
+Storage is charged in three parts -- `storage_cost`, `-storage_rebate`, and `non_refundable_storage_fee` -- independently of `computation_cost`.
+
+The overall cost of a transaction, deducted from its gas coins, is its `computation_cost + storage_cost - storage_rebate`. `non_refundable_storage_fee` is collected from objects being mutated or deleted and accumulated by the system in storage funds, the remaining storage costs of previous object versions are what become the `storage_rebate`. The ratio between `non_refundable_storage_fee` and `storage_rebate` is set by the protocol.
+"""
+type GasCostSummary {
+  """
+  The sum cost of computation/execution
+  """
+  computationCost: UInt53
+
+  """
+  Cost for storage at the time the transaction is executed, calculated as the size of the objects being mutated in bytes multiplied by a storage cost per byte (part of the protocol).
+  """
+  storageCost: UInt53
+
+  """
+  Amount the user gets back from the storage cost of the previous versions of objects being mutated or deleted.
+  """
+  storageRebate: UInt53
+
+  """
+  Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
+  """
+  nonRefundableStorageFee: UInt53
+}
+
+"""
+Effects related to gas (costs incurred and the identity of the smashed gas object returned).
+"""
+type GasEffects {
+  """
+  The gas object used to pay for this transaction. If multiple gas coins were provided, this represents the combined coin after smashing.
+  """
+  gasObject: Object
+
+  """
+  Breakdown of the gas costs for this transaction.
+  """
+  gasSummary: GasCostSummary
+}
+
+type GasInput {
+  """
+  Address of the owner of the gas object(s) used.
+  """
+  gasSponsor: Address
+
+  """
+  An unsigned integer specifying the number of native tokens per gas unit this transaction will pay (in MIST).
+  """
+  gasPrice: BigInt
+
+  """
+  The maximum SUI that can be expended by executing this transaction
+  """
+  gasBudget: BigInt
+
+  """
+  Objects used to pay for a transaction's execution and storage
+  """
+  gasPayment(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): ObjectConnection
+}
+
+"""
+System transaction that initializes the network and writes the initial set of objects on-chain.
+"""
+type GenesisTransaction {
+  """
+  Objects to be created during genesis.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): ObjectConnection
+}
+
+"""
+Interface implemented by GraphQL types representing entities that are identified by an address.
+
+An address uniquely represents either the public key of an account, or an object's ID, but never both. It is not possible to determine which type an address represents up-front. If an object is wrapped, its contents will not be accessible via its address, but it will still be possible to access other objects it owns.
+"""
+interface IAddressable {
+  address: SuiAddress!
+
+  """
+  Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+
+  If the address does not own any coins of that type, a balance of zero is returned.
+  """
+  balance(coinType: String!): Balance
+
+  """
+  Total balance across coins owned by this address, grouped by coin type.
+  """
+  balances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): BalanceConnection
+
+  """
+  The domain explicitly configured as the default SuiNS name for this address.
+  """
+  defaultSuinsName: String
+
+  """
+  Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+
+  Returns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.
+  """
+  multiGetBalances(keys: [String!]!): [Balance!]
+
+  """
+  Objects owned by this address, optionally filtered by type.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: ObjectFilter
+  ): MoveObjectConnection
+}
+
+"""
+Interface implemented by all GraphQL types that represent a Move datatype definition (either a struct or an enum definition).
+
+This interface is used to provide a way to access fields that are shared by both structs and enums, e.g., the module that the datatype belongs to, the name of the datatype, type parameters etc.
+"""
+interface IMoveDatatype {
+  """
+  The module that this datatype is defined in
+  """
+  module: MoveModule!
+
+  """
+  The datatype's unqualified name
+  """
+  name: String!
+
+  """
+  Abilities on this datatype definition.
+  """
+  abilities: [MoveAbility!]
+
+  """
+  Constraints on the datatype's formal type parameters
+
+  Move bytecode does not name type parameters, so when they are referenced (e.g. in field types), they are identified by their index in this list.
+  """
+  typeParameters: [MoveDatatypeTypeParameter!]
+}
+
+"""
+Interface implemented by types that represent a Move object on-chain (A Move value whose type has `key`).
+"""
+interface IMoveObject {
+  """
+  The structured representation of the object's contents.
+  """
+  contents: MoveValue
+
+  """
+  Access a dynamic field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic field with that name could not be found attached to this object.
+  """
+  dynamicField(name: DynamicFieldName!): DynamicField
+
+  """
+  Access a dynamic object field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic object field with that name could not be found attached to this object.
+  """
+  dynamicObjectField(name: DynamicFieldName!): DynamicField
+
+  """
+  Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+
+  Both these operations require the object to have both the `key` and `store` abilities.
+  """
+  hasPublicTransfer: Boolean
+
+  """
+  Access dynamic fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  Access dynamic object fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  Dynamic fields and dynamic object fields owned by this object.
+
+  Dynamic fields on wrapped objects can be accessed using `Address.dynamicFields`.
+  """
+  dynamicFields(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): DynamicFieldConnection
+
+  """
+  The Base64-encoded BCS serialize of this object, as a `MoveObject`.
+  """
+  moveObjectBcs: Base64
+}
+
+"""
+Interface implemented by versioned on-chain values that are addressable by an ID (also referred to as its address). This includes Move objects and packages.
+"""
+interface IObject {
+  """
+  The version of this object that this content comes from.
+  """
+  version: UInt53
+
+  """
+  32-byte hash that identifies the object's contents, encoded in Base58.
+  """
+  digest: String
+
+  """
+  Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
+  """
+  objectAt(version: UInt53, rootVersion: UInt53, checkpoint: UInt53): Object
+
+  """
+  The Base64-encoded BCS serialization of this object, as an `Object`.
+  """
+  objectBcs: Base64
+
+  """
+  Paginate all versions of this object after this one.
+  """
+  objectVersionsAfter(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Paginate all versions of this object before this one.
+  """
+  objectVersionsBefore(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  The object's owner kind.
+  """
+  owner: Owner
+
+  """
+  The transaction that created this version of the object
+  """
+  previousTransaction: Transaction
+
+  """
+  The SUI returned to the sponsor or sender of the transaction that modifies or deletes this object.
+  """
+  storageRebate: BigInt
+
+  """
+  The transactions that sent objects to this object.
+  """
+  receivedTransactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: TransactionFilter
+  ): TransactionConnection
+}
+
+"""
+Object is accessible to all addresses, and is immutable.
+"""
+type Immutable {
+  _: Boolean
+}
+
+type Input {
+  """
+  The index of the input.
+  """
+  ix: Int
+}
+
+"""
+Arbitrary JSON data.
+"""
+scalar JSON
+
+"""
+Information used by a package to link to a specific version of its dependency.
+"""
+type Linkage {
+  """
+  The ID on-chain of the first version of the dependency.
+  """
+  originalId: SuiAddress
+
+  """
+  The ID on-chain of the version of the dependency that this package depends on.
+  """
+  upgradedId: SuiAddress
+
+  """
+  The version of the dependency that this package depends on.
+  """
+  version: UInt53
+}
+
+"""
+Create a vector (can be empty).
+"""
+type MakeMoveVecCommand {
+  """
+  If the elements are not objects, or the vector is empty, a type must be supplied.
+  """
+  type: MoveType
+
+  """
+  The values to pack into the vector, all of the same type.
+  """
+  elements: [TransactionArgument!]
+}
+
+"""
+Merges `coins` into the first `coin` (produces no results).
+"""
+type MergeCoinsCommand {
+  """
+  The coin to merge into.
+  """
+  coin: TransactionArgument
+
+  """
+  The coins to be merged.
+  """
+  coins: [TransactionArgument!]!
+}
+
+"""
+Abilities are keywords in Sui Move that define how types behave at the compiler level.
+"""
+enum MoveAbility {
+  """
+  Enables values to be copied.
+  """
+  COPY
+
+  """
+  Enables values to be popped/dropped.
+  """
+  DROP
+
+  """
+  Enables values to be held directly in global storage.
+  """
+  KEY
+
+  """
+  Enables values to be held inside a struct in global storage.
+  """
+  STORE
+}
+
+type MoveCallCommand {
+  """
+  The function being called.
+  """
+  function: MoveFunction!
+
+  """
+  The actual function parameters passed in for this move call.
+  """
+  arguments: [TransactionArgument!]!
+}
+
+"""
+Description of a datatype, defined in a Move module.
+"""
+type MoveDatatype implements IMoveDatatype {
+  """
+  The module that this datatype is defined in.
+  """
+  module: MoveModule!
+
+  """
+  The datatype's unqualified name.
+  """
+  name: String!
+
+  """
+  Abilities on this datatype definition.
+  """
+  abilities: [MoveAbility!]
+
+  """
+  Attempts to convert the `MoveDatatype` to a `MoveStruct`.
+  """
+  asMoveStruct: MoveStruct
+
+  """
+  Attempts to convert the `MoveDatatype` to a `MoveEnum`.
+  """
+  asMoveEnum: MoveEnum
+
+  """
+  Constraints on the datatype's formal type parameters.
+
+  Move bytecode does not name type parameters, so when they are referenced (e.g. in field types), they are identified by their index in this list.
+  """
+  typeParameters: [MoveDatatypeTypeParameter!]
+}
+
+type MoveDatatypeConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [MoveDatatypeEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [MoveDatatype!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveDatatypeEdge {
+  """
+  The item at the end of the edge
+  """
+  node: MoveDatatype!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+Declaration of a type parameter on a Move struct.
+"""
+type MoveDatatypeTypeParameter {
+  """
+  Ability constraints on this type parameter.
+  """
+  constraints: [MoveAbility!]!
+
+  """
+  Whether this type parameter is marked `phantom` or not.
+
+  Phantom type parameters are not referenced in the struct's fields.
+  """
+  isPhantom: Boolean!
+}
+
+"""
+Description of an enum type, defined in a Move module.
+"""
+type MoveEnum implements IMoveDatatype {
+  """
+  The module that this enum is defined in.
+  """
+  module: MoveModule!
+
+  """
+  The enum's unqualified name.
+  """
+  name: String!
+
+  """
+  Abilities on this enum definition.
+  """
+  abilities: [MoveAbility!]
+
+  """
+  The names and fields of the enum's variants
+
+  Field types reference type parameters by their index in the defining enum's `typeParameters` list.
+  """
+  variants: [MoveEnumVariant!]
+
+  """
+  Constraints on the enum's formal type parameters.
+
+  Move bytecode does not name type parameters, so when they are referenced (e.g. in field types), they are identified by their index in this list.
+  """
+  typeParameters: [MoveDatatypeTypeParameter!]
+}
+
+type MoveEnumConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [MoveEnumEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [MoveEnum!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveEnumEdge {
+  """
+  The item at the end of the edge
+  """
+  node: MoveEnum!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+type MoveEnumVariant {
+  """
+  The variant's name.
+  """
+  name: String
+
+  """
+  The names and types of the variant's fields.
+
+  Field types reference type parameters by their index in the defining struct's `typeParameters` list.
+  """
+  fields: [MoveField!]
+}
+
+type MoveField {
+  """
+  The field's name.
+  """
+  name: String
+
+  """
+  The field's type.
+
+  This type can reference type parameters introduced by the defining struct (see `typeParameters`).
+  """
+  type: OpenMoveType
+}
+
+"""
+A function defined in a Move module.
+"""
+type MoveFunction {
+  """
+  The module that this function is defined in.
+  """
+  module: MoveModule!
+
+  """
+  The function's unqualified name.
+  """
+  name: String!
+
+  """
+  Whether the function is marked `entry` or not.
+  """
+  isEntry: Boolean
+
+  """
+  The function's parameter types. These types can reference type parameters introduced by this function (see `typeParameters`).
+  """
+  parameters: [OpenMoveType!]
+
+  """
+  The function's return types. There can be multiple because functions in Move can return multiple values. These types can reference type parameters introduced by this function (see `typeParameters`).
+  """
+  return: [OpenMoveType!]
+
+  """
+  Constraints on the function's formal type parameters.
+
+  Move bytecode does not name type parameters, so when they are referenced (e.g. in parameter and return types), they are identified by their index in this list.
+  """
+  typeParameters: [MoveFunctionTypeParameter!]
+
+  """
+  The function's visibility: `public`, `public(friend)`, or `private`.
+  """
+  visibility: MoveVisibility
+}
+
+type MoveFunctionConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [MoveFunctionEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [MoveFunction!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveFunctionEdge {
+  """
+  The item at the end of the edge
+  """
+  node: MoveFunction!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+Declaration of a type parameter on a Move function.
+"""
+type MoveFunctionTypeParameter {
+  """
+  Ability constraints on this type parameter.
+  """
+  constraints: [MoveAbility!]!
+}
+
+"""
+Modules are a unit of code organization in Move.
+
+Modules belong to packages, and contain type and function definitions.
+"""
+type MoveModule {
+  """
+  The package that this module was defined in.
+  """
+  package: MovePackage
+
+  """
+  The module's unqualified name.
+  """
+  name: String!
+
+  """
+  Base64 encoded bytes of the serialized CompiledModule.
+  """
+  bytes: Base64
+
+  """
+  The datatype (struct or enum) named `name` in this module.
+  """
+  datatype(name: String!): MoveDatatype
+
+  """
+  Paginate through this module's datatype definitions.
+  """
+  datatypes(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): MoveDatatypeConnection
+
+  """
+  Textual representation of the module's bytecode.
+  """
+  disassembly: String
+
+  """
+  The enum named `name` in this module.
+  """
+  enum(name: String!): MoveEnum
+
+  """
+  Paginate through this module's enum definitions.
+  """
+  enums(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): MoveEnumConnection
+
+  """
+  Bytecode format version.
+  """
+  fileFormatVersion: Int
+
+  """
+  Modules that this module considers friends. These modules can call `public(package)` functions in this module.
+  """
+  friends(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): MoveModuleConnection
+
+  """
+  The function named `name` in this module.
+  """
+  function(name: String!): MoveFunction
+
+  """
+  Paginate through this module's function definitions.
+  """
+  functions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): MoveFunctionConnection
+
+  """
+  The struct named `name` in this module.
+  """
+  struct(name: String!): MoveStruct
+
+  """
+  Paginate through this module's struct definitions.
+  """
+  structs(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): MoveStructConnection
+}
+
+type MoveModuleConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [MoveModuleEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [MoveModule!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveModuleEdge {
+  """
+  The item at the end of the edge
+  """
+  node: MoveModule!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A MoveObject is a kind of Object that reprsents data stored on-chain.
+"""
+type MoveObject implements IAddressable & IMoveObject & IObject {
+  """
+  The MoveObject's ID.
+  """
+  address: SuiAddress!
+
+  """
+  The version of this object that this content comes from.
+  """
+  version: UInt53
+
+  """
+  32-byte hash that identifies the object's contents, encoded in Base58.
+  """
+  digest: String
+
+  """
+  Attempts to convert the object into a CoinMetadata.
+  """
+  asCoinMetadata: CoinMetadata
+
+  """
+  Attempts to convert the object into a DynamicField.
+  """
+  asDynamicField: DynamicField
+
+  """
+  Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+
+  If the address does not own any coins of that type, a balance of zero is returned.
+  """
+  balance(coinType: String!): Balance
+
+  """
+  Total balance across coins owned by this address, grouped by coin type.
+  """
+  balances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): BalanceConnection
+
+  """
+  The structured representation of the object's contents.
+  """
+  contents: MoveValue
+
+  """
+  The domain explicitly configured as the default SuiNS name for this address.
+  """
+  defaultSuinsName: String
+
+  """
+  Access a dynamic field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic field with that name could not be found attached to this object.
+  """
+  dynamicField(name: DynamicFieldName!): DynamicField
+
+  """
+  Dynamic fields owned by this object.
+
+  Dynamic fields on wrapped objects can be accessed using `Address.dynamicFields`.
+  """
+  dynamicFields(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): DynamicFieldConnection
+
+  """
+  Access a dynamic object field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic object field with that name could not be found attached to this object.
+  """
+  dynamicObjectField(name: DynamicFieldName!): DynamicField
+
+  """
+  Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+
+  Both these operations require the object to have both the `key` and `store` abilities.
+  """
+  hasPublicTransfer: Boolean
+
+  """
+  Access dynamic fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+
+  If the address does not own any coins of a given type, a balance of zero is returned for that type.
+  """
+  multiGetBalances(keys: [String!]!): [Balance!]
+
+  """
+  Access dynamic object fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  The Base64-encoded BCS serialize of this object, as a `MoveObject`.
+  """
+  moveObjectBcs: Base64
+
+  """
+  Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
+
+  If no additional bound is provided, the latest version of this object is fetched at the latest checkpoint.
+  """
+  objectAt(version: UInt53, rootVersion: UInt53, checkpoint: UInt53): Object
+
+  """
+  The Base64-encoded BCS serialization of this object, as an `Object`.
+  """
+  objectBcs: Base64
+
+  """
+  Paginate all versions of this object after this one.
+  """
+  objectVersionsAfter(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Paginate all versions of this object before this one.
+  """
+  objectVersionsBefore(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Objects owned by this object, optionally filtered by type.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: ObjectFilter
+  ): MoveObjectConnection
+
+  """
+  The object's owner kind.
+  """
+  owner: Owner
+
+  """
+  The transaction that created this version of the object.
+  """
+  previousTransaction: Transaction
+
+  """
+  The SUI returned to the sponsor or sender of the transaction that modifies or deletes this object.
+  """
+  storageRebate: BigInt
+
+  """
+  The transactions that sent objects to this object.
+  """
+  receivedTransactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: TransactionFilter
+  ): TransactionConnection
+}
+
+type MoveObjectConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [MoveObjectEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [MoveObject!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveObjectEdge {
+  """
+  The item at the end of the edge
+  """
+  node: MoveObject!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A MovePackage is a kind of Object that represents code that has been published on-chain. It exposes information about its modules, type definitions, functions, and dependencies.
+"""
+type MovePackage implements IAddressable & IObject {
+  """
+  The MovePackage's ID.
+  """
+  address: SuiAddress!
+
+  """
+  The version of this package that this content comes from.
+  """
+  version: UInt53
+
+  """
+  32-byte hash that identifies the package's contents, encoded in Base58.
+  """
+  digest: String
+
+  """
+  Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+
+  If the address does not own any coins of that type, a balance of zero is returned.
+  """
+  balance(coinType: String!): Balance
+
+  """
+  Total balance across coins owned by this address, grouped by coin type.
+  """
+  balances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): BalanceConnection
+
+  """
+  The domain explicitly configured as the default SuiNS name for this address.
+  """
+  defaultSuinsName: String
+
+  """
+  The module named `name` in this package.
+  """
+  module(name: String!): MoveModule
+
+  """
+  Paginate through this package's modules.
+  """
+  modules(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): MoveModuleConnection
+
+  """
+  BCS representation of the package's modules.  Modules appear as a sequence of pairs (module name, followed by module bytes), in alphabetic order by module name.
+  """
+  moduleBcs: Base64
+
+  """
+  Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+
+  If the address does not own any coins of a given type, a balance of zero is returned for that type.
+  """
+  multiGetBalances(keys: [String!]!): [Balance!]
+
+  """
+  Objects owned by this package, optionally filtered by type.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: ObjectFilter
+  ): MoveObjectConnection
+
+  """
+  Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
+
+  If no additional bound is provided, the latest version of this object is fetched at the latest checkpoint.
+  """
+  objectAt(version: UInt53, rootVersion: UInt53, checkpoint: UInt53): Object
+
+  """
+  The Base64-encoded BCS serialization of this package, as an `Object`.
+  """
+  objectBcs: Base64
+
+  """
+  Paginate all versions of this package treated as an object, after this one.
+  """
+  objectVersionsAfter(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Paginate all versions of this package treated as an object, before this one.
+  """
+  objectVersionsBefore(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  The object's owner kind.
+  """
+  owner: Owner
+
+  """
+  Fetch the package with the same original ID, at a different version, root version bound, or checkpoint.
+
+  If no additional bound is provided, the latest version of this package is fetched at the latest checkpoint.
+  """
+  packageAt(version: UInt53, checkpoint: UInt53): MovePackage
+
+  """
+  The Base64-encoded BCS serialization of this package, as a `MovePackage`.
+  """
+  packageBcs: Base64
+
+  """
+  Paginate all versions of this package after this one.
+  """
+  packageVersionsAfter(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): MovePackageConnection
+
+  """
+  Paginate all versions of this package before this one.
+  """
+  packageVersionsBefore(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): MovePackageConnection
+
+  """
+  The transaction that created this version of the object.
+  """
+  previousTransaction: Transaction
+
+  """
+  The transitive dependencies of this package.
+  """
+  linkage: [Linkage!]
+
+  """
+  The SUI returned to the sponsor or sender of the transaction that modifies or deletes this object.
+  """
+  storageRebate: BigInt
+
+  """
+  The transactions that sent objects to this object.
+  """
+  receivedTransactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: TransactionFilter
+  ): TransactionConnection
+
+  """
+  A table identifying which versions of a package introduced each of its types.
+  """
+  typeOrigins: [TypeOrigin!]
+}
+
+type MovePackageConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [MovePackageEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [MovePackage!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MovePackageEdge {
+  """
+  The item at the end of the edge
+  """
+  node: MovePackage!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+Description of a struct type, defined in a Move module.
+"""
+type MoveStruct implements IMoveDatatype {
+  """
+  The module that this struct is defined in.
+  """
+  module: MoveModule!
+
+  """
+  The struct's unqualified name.
+  """
+  name: String!
+
+  """
+  Abilities on this struct definition.
+  """
+  abilities: [MoveAbility!]
+
+  """
+  The names and types of the struct's fields.
+
+  Field types reference type parameters by their index in the defining struct's `typeParameters` list.
+  """
+  fields: [MoveField!]
+
+  """
+  Constraints on the struct's formal type parameters.
+
+  Move bytecode does not name type parameters, so when they are referenced (e.g. in field types), they are identified by their index in this list.
+  """
+  typeParameters: [MoveDatatypeTypeParameter!]
+}
+
+type MoveStructConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [MoveStructEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [MoveStruct!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveStructEdge {
+  """
+  The item at the end of the edge
+  """
+  node: MoveStruct!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+Represents instances of concrete types (no type parameters, no references).
+"""
+type MoveType {
+  """
+  Flat representation of the type signature, as a displayable string.
+  """
+  repr: String!
+
+  """
+  Structured representation of the type signature.
+  """
+  signature: MoveTypeSignature!
+
+  """
+  Structured representation of the "shape" of values that match this type. May return no
+  layout if the type is invalid.
+  """
+  layout: MoveTypeLayout
+
+  """
+  The abilities this concrete type has. Returns no abilities if the type is invalid.
+  """
+  abilities: [MoveAbility!]
+}
+
+"""
+The shape of a concrete Move Type (a type with all its type parameters instantiated with concrete types), corresponding to the following recursive type:
+
+type MoveTypeLayout =
+    "address"
+  | "bool"
+  | "u8" | "u16" | ... | "u256"
+  | { vector: MoveTypeLayout }
+  | {
+      struct: {
+        type: string,
+        fields: [{ name: string, layout: MoveTypeLayout }],
+      }
+    }
+  | { enum: [{
+          type: string,
+          variants: [{
+              name: string,
+              fields: [{ name: string, layout: MoveTypeLayout }],
+          }]
+      }]
+  }
+"""
+scalar MoveTypeLayout
+
+"""
+The signature of a concrete Move Type (a type with all its type parameters instantiated with concrete types, that contains no references), corresponding to the following recursive type:
+
+type MoveTypeSignature =
+    "address"
+  | "bool"
+  | "u8" | "u16" | ... | "u256"
+  | { vector: MoveTypeSignature }
+  | {
+      datatype: {
+        package: string,
+        module: string,
+        type: string,
+        typeParameters: [MoveTypeSignature],
+      }
+    }
+"""
+scalar MoveTypeSignature
+
+type MoveValue {
+  """
+  The BCS representation of this value, Base64-encoded.
+  """
+  bcs: Base64
+
+  """
+  A rendered JSON blob based on an on-chain template, substituted with data from this value.
+
+  Returns `null` if the value's type does not have an associated `Display` template.
+  """
+  display: Display
+
+  """
+  Representation of a Move value in JSON, where:
+
+  - Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
+  - Bools are represented by JSON boolean literals.
+  - u8, u16, and u32 are represented as JSON numbers.
+  - u64, u128, and u256 are represented as JSON strings.
+  - Balances, Strings, and Urls are represented as JSON strings.
+  - Vectors of bytes are represented as Base64 blobs, and other vectors are represented by JSON arrays.
+  - Structs are represented by JSON objects.
+  - Enums are represented by JSON objects, with a field named `@variant` containing the variant name.
+  - Empty optional values are represented by `null`.
+  """
+  json: JSON
+
+  """
+  The value's type.
+  """
+  type: MoveType
+}
+
+"""
+The visibility modifier describes which modules can access this module member.
+
+By default, a module member can be called only within the same module.
+"""
+enum MoveVisibility {
+  """
+  A public member can be accessed by any module.
+  """
+  PUBLIC
+
+  """
+  A private member can be accessed in the module it is defined in.
+  """
+  PRIVATE
+
+  """
+  A friend member can be accessed in the module it is defined in and any other module in its package that is explicitly specified in its friend list.
+  """
+  FRIEND
+}
+
+"""
+A transaction that wanted to mutate a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
+"""
+type MutateConsensusStreamEnded {
+  """
+  The ID of the consensus-managed object.
+  """
+  address: SuiAddress
+
+  """
+  The sequence number associated with the consensus stream ending.
+  """
+  sequenceNumber: UInt53
+}
+
+"""
+Mutations are used to write to the Sui network.
+"""
+type Mutation {
+  """
+  Execute a transaction, committing its effects on chain.
+
+  - `transactionDataBcs` contains the BCS-encoded transaction data (Base64-encoded).
+  - `signatures` are a list of `flag || signature || pubkey` bytes, Base64-encoded.
+
+  Waits until the transaction has reached finality on chain to return its transaction digest, or returns the error that prevented finality if that was not possible. A transaction is final when its effects are guaranteed on chain (it cannot be revoked).
+
+  There may be a delay between transaction finality and when GraphQL requests (including the request that issued the transaction) reflect its effects. As a result, queries that depend on indexing the state of the chain (e.g. contents of output objects, address-level balance information at the time of the transaction), must wait for indexing to catch up by polling for the transaction digest using `Query.transaction`.
+  """
+  executeTransaction(
+    transactionDataBcs: Base64!
+    signatures: [Base64!]!
+  ): ExecutionResult!
+}
+
+"""
+An Object on Sui is either a typed value (a Move Object) or a Package (modules containing functions and types).
+
+Every object on Sui is identified by a unique address, and has a version number that increases with every modification. Objects also hold metadata detailing their current owner (who can sign for access to the object and whether that access can modify and/or delete the object), and the digest of the last transaction that modified the object.
+"""
+type Object implements IAddressable & IObject {
+  """
+  The Object's ID.
+  """
+  address: SuiAddress!
+
+  """
+  The version of this object that this content comes from.
+  """
+  version: UInt53
+
+  """
+  32-byte hash that identifies the object's contents, encoded in Base58.
+  """
+  digest: String
+
+  """
+  Attempts to convert the object into a MoveObject.
+  """
+  asMoveObject: MoveObject
+
+  """
+  Attempts to convert the object into a MovePackage.
+  """
+  asMovePackage: MovePackage
+
+  """
+  Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+
+  If the address does not own any coins of that type, a balance of zero is returned.
+  """
+  balance(coinType: String!): Balance
+
+  """
+  Total balance across coins owned by this address, grouped by coin type.
+  """
+  balances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): BalanceConnection
+
+  """
+  The domain explicitly configured as the default SuiNS name for this address.
+  """
+  defaultSuinsName: String
+
+  """
+  Access a dynamic field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic field with that name could not be found attached to this object.
+  """
+  dynamicField(name: DynamicFieldName!): DynamicField
+
+  """
+  Dynamic fields owned by this object.
+  """
+  dynamicFields(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): DynamicFieldConnection
+
+  """
+  Access a dynamic object field on an object using its type and BCS-encoded name.
+
+  Returns `null` if a dynamic object field with that name could not be found attached to this object.
+  """
+  dynamicObjectField(name: DynamicFieldName!): DynamicField
+
+  """
+  Access dynamic fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  Access dynamic object fields on an object using their types and BCS-encoded names.
+
+  Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+  """
+  multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
+
+  """
+  Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+
+  Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+  If the address does not own any coins of a given type, a balance of zero is returned for that type.
+  """
+  multiGetBalances(keys: [String!]!): [Balance!]
+
+  """
+  Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
+
+  If no additional bound is provided, the latest version of this object is fetched at the latest checkpoint.
+  """
+  objectAt(version: UInt53, rootVersion: UInt53, checkpoint: UInt53): Object
+
+  """
+  The Base64-encoded BCS serialization of this object, as an `Object`.
+  """
+  objectBcs: Base64
+
+  """
+  Paginate all versions of this object after this one.
+  """
+  objectVersionsAfter(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Paginate all versions of this object before this one.
+  """
+  objectVersionsBefore(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Objects owned by this object, optionally filtered by type.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: ObjectFilter
+  ): MoveObjectConnection
+
+  """
+  The object's owner kind.
+  """
+  owner: Owner
+
+  """
+  The transaction that created this version of the object.
+  """
+  previousTransaction: Transaction
+
+  """
+  The SUI returned to the sponsor or sender of the transaction that modifies or deletes this object.
+  """
+  storageRebate: BigInt
+
+  """
+  The transactions that sent objects to this object
+  """
+  receivedTransactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: TransactionFilter
+  ): TransactionConnection
+}
+
+type ObjectChange {
+  """
+  The address of the object that has changed.
+  """
+  address: SuiAddress!
+
+  """
+  The contents of the object immediately before the transaction.
+  """
+  inputState: Object
+
+  """
+  The contents of the object immediately after the transaction.
+  """
+  outputState: Object
+
+  """
+  Whether the ID was created in this transaction.
+  """
+  idCreated: Boolean
+
+  """
+  Whether the ID was deleted in this transaction.
+  """
+  idDeleted: Boolean
+}
+
+type ObjectChangeConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [ObjectChangeEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [ObjectChange!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ObjectChangeEdge {
+  """
+  The item at the end of the edge
+  """
+  node: ObjectChange!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+type ObjectConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [ObjectEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [Object!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ObjectEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Object!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+A filter over the live object set, the filter can be one of:
+
+- A filter on type (all live objects whose type matches that filter).
+- Fetching all objects owned by an address or object, optionally filtered by type.
+- Fetching all shared or immutable objects, filtered by type.
+"""
+input ObjectFilter {
+  """
+  Filter on whether the object is address-owned, object-owned, shared, or immutable.
+
+  - If this field is set to "ADDRESS" or "OBJECT", then an owner filter must also be provided.
+  - If this field is set to "SHARED" or "IMMUTABLE", then a type filter must also be provided.
+  """
+  ownerKind: OwnerKind
+
+  """
+  Specifies the address of the owning address or object.
+
+  This field is required if `ownerKind` is "ADDRESS" or "OBJECT". If provided without `ownerKind`, `ownerKind` defaults to "ADDRESS".
+  """
+  owner: SuiAddress
+
+  """
+  Filter on the object's type.
+
+  The filter can be one of:
+
+  - A package address: `0x2`,
+  - A module: `0x2::coin`,
+  - A fully-qualified name: `0x2::coin::Coin`,
+  - A type instantiation: `0x2::coin::Coin<0x2::sui::SUI>`.
+  """
+  type: String
+}
+
+"""
+Identifies a specific version of an object.
+
+The `address` field must be specified, as well as at most one of `version`, `rootVersion`, or `atCheckpoint`. If none are provided, the object is fetched at the current checkpoint.
+
+Specifying a `version` or a `rootVersion` disables nested queries for paginating owned objects or dynamic fields (these queries are only supported at checkpoint boundaries).
+
+See `Query.object` for more details.
+"""
+input ObjectKey {
+  """
+  The object's ID.
+  """
+  address: SuiAddress!
+
+  """
+  If specified, tries to fetch the object at this exact version.
+  """
+  version: UInt53
+
+  """
+  If specified, tries to fetch the latest version of the object at or before this version. Nested dynamic field accesses will also be subject to this bound.
+
+  This can be used to fetch a child or ancestor object bounded by its root object's version. For any wrapped or child (object-owned) object, its root object can be defined recursively as:
+
+  - The root object of the object it is wrapped in, if it is wrapped.
+  - The root object of its owner, if it is owned by another object.
+  - The object itself, if it is not object-owned or wrapped.
+  """
+  rootVersion: UInt53
+
+  """
+  If specified, tries to fetch the latest version as of this checkpoint. Fails if the checkpoint is later than the RPC's latest checkpoint.
+  """
+  atCheckpoint: UInt53
+}
+
+"""
+Object is exclusively owned by a single object, and is mutable. Note that the owning object may be inaccessible because it is wrapped.
+"""
+type ObjectOwner {
+  """
+  The owner's address.
+  """
+  address: Address
+}
+
+"""
+Represents types that could contain references or free type parameters.  Such types can appear
+as function parameters, in fields of structs, or as actual type parameter.
+"""
+type OpenMoveType {
+  """
+  Structured representation of the type signature.
+  """
+  signature: OpenMoveTypeSignature!
+
+  """
+  Flat representation of the type signature, as a displayable string.
+  """
+  repr: String!
+}
+
+"""
+The shape of an abstract Move Type (a type that can contain free type parameters, and can optionally be taken by reference), corresponding to the following recursive type:
+
+type OpenMoveTypeSignature = {
+  ref: ("&" | "&mut")?,
+  body: OpenMoveTypeSignatureBody,
+}
+
+type OpenMoveTypeSignatureBody =
+    "address"
+  | "bool"
+  | "u8" | "u16" | ... | "u256"
+  | { vector: OpenMoveTypeSignatureBody }
+  | {
+      datatype {
+        package: string,
+        module: string,
+        type: string,
+        typeParameters: [OpenMoveTypeSignatureBody]
+      }
+    }
+  | { typeParameter: number }
+"""
+scalar OpenMoveTypeSignature
+
+"""
+Placeholder for unimplemented command types
+"""
+type OtherCommand {
+  """
+  Placeholder field for unimplemented commands
+  """
+  _: Boolean
+}
+
+"""
+A Move object, either immutable, or owned mutable.
+"""
+type OwnedOrImmutable {
+  object: Object
+}
+
+"""
+The object's owner kind.
+"""
+union Owner =
+    AddressOwner
+  | ObjectOwner
+  | Shared
+  | Immutable
+  | ConsensusAddressOwner
+
+"""
+Filter on who owns an object.
+"""
+enum OwnerKind {
+  """
+  Object is owned by an address.
+  """
+  ADDRESS
+
+  """
+  Object is a child of another object (e.g. a dynamic field or dynamic object field).
+  """
+  OBJECT
+
+  """
+  Object is shared among multiple owners.
+  """
+  SHARED
+
+  """
+  Object is frozen.
+  """
+  IMMUTABLE
+}
+
+"""
+Filter for paginating packages published within a range of checkpoints.
+"""
+input PackageCheckpointFilter {
+  """
+  Filter to packages that were published strictly after this checkpoint, defaults to fetching from the earliest checkpoint known to this RPC (this could be the genesis checkpoint, or some later checkpoint if data has been pruned).
+  """
+  afterCheckpoint: UInt53
+
+  """
+  Filter to packages published strictly before this checkpoint, defaults to fetching up to the latest checkpoint (inclusive).
+  """
+  beforeCheckpoint: UInt53
+}
+
+"""
+Identifies a specific version of a package.
+
+The `address` field must be specified, as well as at most one of `version`, or `atCheckpoint`. If neither is provided, the package is fetched at the current checkpoint.
+
+See `Query.package` for more details.
+"""
+input PackageKey {
+  """
+  The object's ID.
+  """
+  address: SuiAddress!
+
+  """
+  If specified, tries to fetch the package at this exact version.
+  """
+  version: UInt53
+
+  """
+  If specified, tries to fetch the latest version as of this checkpoint.
+  """
+  atCheckpoint: UInt53
+}
+
+"""
+Information about pagination in a connection
+"""
+type PageInfo {
+  """
+  When paginating backwards, are there more items?
+  """
+  hasPreviousPage: Boolean!
+
+  """
+  When paginating forwards, are there more items?
+  """
+  hasNextPage: Boolean!
+
+  """
+  When paginating backwards, the cursor to continue.
+  """
+  startCursor: String
+
+  """
+  When paginating forwards, the cursor to continue.
+  """
+  endCursor: String
+}
+
+type PerEpochConfig {
+  """
+  The per-epoch configuration object as of when the transaction was executed.
+  """
+  object: Object
+}
+
+"""
+ProgrammableSystemTransaction is identical to ProgrammableTransaction, but GraphQL does not allow multiple variants with the same type.
+"""
+type ProgrammableSystemTransaction {
+  """
+  Input objects or primitive values.
+  """
+  inputs(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): TransactionInputConnection
+
+  """
+  The transaction commands, executed sequentially.
+  """
+  commands(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): CommandConnection
+}
+
+type ProgrammableTransaction {
+  """
+  Input objects or primitive values.
+  """
+  inputs(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): TransactionInputConnection
+
+  """
+  The transaction commands, executed sequentially.
+  """
+  commands(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): CommandConnection
+}
+
+"""
+A protocol configuration that can hold an arbitrary value (or no value at all).
+"""
+type ProtocolConfig {
+  """
+  Configuration name.
+  """
+  key: String!
+
+  """
+  Configuration value.
+  """
+  value: String
+}
+
+"""
+Constants that control how the chain operates.
+
+These can only change during protocol upgrades which happen on epoch boundaries. Configuration is split into feature flags (which are just booleans), and configs which can take any value (including no value at all), and will be represented by a string.
+"""
+type ProtocolConfigs {
+  protocolVersion: UInt53!
+
+  """
+  Query for the value of the configuration with name `key`.
+  """
+  config(key: String!): ProtocolConfig
+
+  """
+  List all available configurations and their values.
+  """
+  configs: [ProtocolConfig!]!
+
+  """
+  Query for the state of the feature flag with name `key`.
+  """
+  featureFlag(key: String!): FeatureFlag
+
+  """
+  List all available feature flags and their values.
+  """
+  featureFlags: [FeatureFlag!]!
+}
+
+"""
+Publishes a Move Package.
+"""
+type PublishCommand {
+  """
+  Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+  """
+  modules: [Base64!]
+
+  """
+  IDs of the transitive dependencies of the package to be published.
+  """
+  dependencies: [SuiAddress!]
+}
+
+"""
+BCS encoded primitive value (not an object or Move struct).
+"""
+type Pure {
+  """
+  BCS serialized and Base64 encoded primitive value.
+  """
+  bytes: Base64
+}
+
+type Query {
+  """
+  Look-up an account by its SuiAddress.
+
+  If `rootVersion` is specified, nested dynamic field accesses will be fetched at or before this version. This can be used to fetch a child or ancestor object bounded by its root object's version, when its immediate parent is wrapped, or a value in a dynamic object field. For any wrapped or child (object-owned) object, its root object can be defined recursively as:
+
+  - The root object of the object it is wrapped in, if it is wrapped.
+  - The root object of its owner, if it is owned by another object.
+  - The object itself, if it is not object-owned or wrapped.
+
+  Specifying a `rootVersion` disables nested queries for paginating owned objects or dynamic fields (these queries are only supported at checkpoint boundaries).
+  """
+  address(address: SuiAddress!, rootVersion: UInt53): Address!
+
+  """
+  First four bytes of the network's genesis checkpoint digest (uniquely identifies the network), hex-encoded.
+  """
+  chainIdentifier: String!
+
+  """
+  Fetch a checkpoint by its sequence number, or the latest checkpoint if no sequence number is provided.
+
+  Returns `null` if the checkpoint does not exist in the store, either because it never existed or because it was pruned.
+  """
+  checkpoint(sequenceNumber: UInt53): Checkpoint
+
+  """
+  Paginate checkpoints in the network, optionally bounded to checkpoints in the given epoch.
+  """
+  checkpoints(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: CheckpointFilter
+  ): CheckpointConnection
+
+  """
+  Fetch the CoinMetadata for a given coin type.
+
+  Returns `null` if no CoinMetadata object exists for the given coin type.
+  """
+  coinMetadata(coinType: String!): CoinMetadata
+
+  """
+  Fetch an epoch by its ID, or fetch the latest epoch if no ID is provided.
+
+  Returns `null` if the epoch does not exist yet, or was pruned.
+  """
+  epoch(epochId: UInt53): Epoch
+
+  """
+  Paginate epochs that are in the network.
+  """
+  epochs(first: Int, after: String, last: Int, before: String): EpochConnection
+
+  """
+  Paginate events that are emitted in the network, optionally filtered by event filters.
+  """
+  events(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: EventFilter
+  ): EventConnection
+
+  """
+  Fetch checkpoints by their sequence numbers.
+
+  Returns a list of checkpoints that is guaranteed to be the same length as `keys`. If a checkpoint in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the checkpoint does not exist yet, or because it was pruned.
+  """
+  multiGetCheckpoints(keys: [UInt53!]!): [Checkpoint]!
+
+  """
+  Fetch epochs by their IDs.
+
+  Returns a list of epochs that is guaranteed to be the same length as `keys`. If an epoch in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the epoch does not exist yet, or because it was pruned.
+  """
+  multiGetEpochs(keys: [UInt53!]!): [Epoch]!
+
+  """
+  Fetch objects by their keys.
+
+  Returns a list of objects that is guaranteed to be the same length as `keys`. If an object in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the object never existed, or because it was pruned.
+  """
+  multiGetObjects(keys: [ObjectKey!]!): [Object]!
+
+  """
+  Fetch packages by their keys.
+
+  Returns a list of packages that is guaranteed to be the same length as `keys`. If a package in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because that address never pointed to a package, or because the package was pruned.
+  """
+  multiGetPackages(keys: [PackageKey!]!): [MovePackage]!
+
+  """
+  Fetch transactions by their digests.
+
+  Returns a list of transactions that is guaranteed to be the same length as `keys`. If a digest in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the transaction never existed, or because it was pruned.
+  """
+  multiGetTransactions(keys: [String!]!): [Transaction]!
+
+  """
+  Fetch transaction effects by their transactions' digests.
+
+  Returns a list of transaction effects that is guaranteed to be the same length as `keys`. If a digest in `keys` could not be found in the store, its corresponding entry in the result will be `null`. This could be because the transaction effects never existed, or because it was pruned.
+  """
+  multiGetTransactionEffects(keys: [String!]!): [TransactionEffects]!
+
+  """
+  Fetch types by their string representations.
+
+  Types are canonicalized: In the input they can be at any package address at or after the package that first defines them, and in the output they will be relocated to the package that first defines them.
+
+  Returns a list of types that is guaranteed to be the same length as `keys`. If a type in `keys` could not be found, its corresponding entry in the result will be `null`.
+  """
+  multiGetTypes(keys: [String!]!): [MoveType]!
+
+  """
+  Fetch an object by its address.
+
+  If `version` is specified, the object will be fetched at that exact version.
+
+  If `rootVersion` is specified, the object will be fetched at the latest version at or before this version. Nested dynamic field accesses will also be subject to this bound. This can be used to fetch a child or ancestor object bounded by its root object's version. For any wrapped or child (object-owned) object, its root object can be defined recursively as:
+
+  - The root object of the object it is wrapped in, if it is wrapped.
+  - The root object of its owner, if it is owned by another object.
+  - The object itself, if it is not object-owned or wrapped.
+
+  Specifying a `version` or a `rootVersion` disables nested queries for paginating owned objects or dynamic fields (these queries are only supported at checkpoint boundaries).
+
+  If `atCheckpoint` is specified, the object will be fetched at the latest version as of this checkpoint. This will fail if the provided checkpoint is after the RPC's latest checkpoint.
+
+  If none of the above are specified, the object is fetched at the latest checkpoint.
+
+  It is an error to specify more than one of `version`, `rootVersion`, or `atCheckpoint`.
+
+  Returns `null` if an object cannot be found that meets this criteria.
+  """
+  object(
+    address: SuiAddress!
+    version: UInt53
+    rootVersion: UInt53
+    atCheckpoint: UInt53
+  ): Object
+
+  """
+  Paginate objects in the live object set, optionally filtered by owner and/or type. `filter` can be one of:
+
+  - A filter on type (all live objects whose type matches that filter).
+  - Fetching all objects owned by an address or object, optionally filtered by type.
+  - Fetching all shared or immutable objects, filtered by type.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: ObjectFilter!
+  ): ObjectConnection
+
+  """
+  Paginate all versions of an object at `address`, optionally bounding the versions exclusively from below with `filter.afterVersion` or from above with `filter.beforeVersion`.
+  """
+  objectVersions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    address: SuiAddress!
+    filter: VersionFilter
+  ): ObjectConnection
+
+  """
+  Fetch a package by its address.
+
+  If `version` is specified, the package loaded is the one that shares its original ID with the package at `address`, but whose version is `version`.
+
+  If `atCheckpoint` is specified, the package loaded is the one with the largest version among all packages sharing an original ID with the package at `address` and was published at or before `atCheckpoint`.
+
+  If neither are specified, the package is fetched at the latest checkpoint.
+
+  It is an error to specify both `version` and `atCheckpoint`, and `null` will be returned if the package cannot be found as of the latest checkpoint, or the address points to an object that is not a package.
+
+  Note that this interpretation of `version` and "latest" differs from the one used by `Query.object`, because non-system package upgrades generate objects with different IDs. To fetch a package using the versioning semantics of objects, use `Object.asMovePackage` nested under `Query.object`.
+  """
+  package(
+    address: SuiAddress!
+    version: UInt53
+    atCheckpoint: UInt53
+  ): MovePackage
+
+  """
+  Paginate all packages published on-chain, optionally bounded to packages published strictly after `filter.afterCheckpoint` and/or strictly before `filter.beforeCheckpoint`.
+  """
+  packages(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: PackageCheckpointFilter
+  ): MovePackageConnection
+
+  """
+  Paginate all versions of a package at `address`, optionally bounding the versions exclusively from below with `filter.afterVersion` or from above with `filter.beforeVersion`.
+
+  Different versions of a package will have different object IDs, unless they are system packages, but will share the same original ID.
+  """
+  packageVersions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    address: SuiAddress!
+    filter: VersionFilter
+  ): MovePackageConnection
+
+  """
+  Fetch the protocol config by protocol version, or the latest protocol config used on chain if no version is provided.
+  """
+  protocolConfigs(version: UInt53): ProtocolConfigs
+
+  """
+  Configuration for this RPC service.
+  """
+  serviceConfig: ServiceConfig!
+
+  """
+  Look-up an account by its SuiNS name, assuming it has a valid, unexpired name registration.
+  """
+  suinsName(address: String!, rootVersion: UInt53): Address
+
+  """
+  Fetch a transaction by its digest.
+
+  Returns `null` if the transaction does not exist in the store, either because it never existed or because it was pruned.
+  """
+  transaction(digest: String!): Transaction
+
+  """
+  Fetch transaction effects by its transaction's digest.
+
+  Returns `null` if the transaction effects do not exist in the store, either because that transaction was not executed, or it was pruned.
+  """
+  transactionEffects(digest: String!): TransactionEffects
+
+  """
+  The transactions that exist in the network, optionally filtered by transaction filters.
+  """
+  transactions(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: TransactionFilter
+  ): TransactionConnection
+
+  """
+  Fetch a structured representation of a concrete type, including its layout information.
+
+  Types are canonicalized: In the input they can be at any package address at or after the package that first defines them, and in the output they will be relocated to the package that first defines them.
+
+  Fails if the type is malformed, returns `null` if a type mentioned does not exist.
+  """
+  type(type: String!): MoveType
+
+  """
+  Simulate a transaction to preview its effects without executing it on chain.
+
+  Accepts a JSON transaction matching the [Sui gRPC API schema](https://docs.sui.io/references/fullnode-protocol#sui-rpc-v2-Transaction).
+  The JSON format allows for partial transaction specification where certain fields can be automatically resolved by the server.
+
+  Alternatively, for already serialized transactions, you can pass BCS-encoded data:
+  `{"bcs": {"value": "<base64>"}}`
+
+  Unlike `executeTransaction`, this does not require signatures since the transaction is not committed to the blockchain. This allows for previewing transaction effects, estimating gas costs, and testing transaction logic without spending gas or requiring valid signatures.
+  """
+  simulateTransaction(transaction: JSON!): SimulationResult!
+
+  """
+  Verify a zkLogin signature os from the given `author`.
+
+  Returns a `ZkLoginVerifyResult` where `success` is `true` and `error` is empty if the signature is valid. If the signature is invalid, `success` is `false` and `error` contains the relevant error message.
+
+  - `bytes` are either the bytes of a serialized personal message, or `TransactionData`, Base64-encoded.
+  - `signature` is a serialized zkLogin signature, also Base64-encoded.
+  - `intentScope` indicates whether `bytes` are to be parsed as a personal message or `TransactionData`.
+  - `author` is the signer's address.
+  """
+  verifyZkLoginSignature(
+    bytes: Base64!
+    signature: Base64!
+    intentScope: ZkLoginIntentScope!
+    author: SuiAddress!
+  ): ZkLoginVerifyResult!
+}
+
+"""
+System transaction for creating the on-chain randomness state.
+"""
+type RandomnessStateCreateTransaction {
+  """
+  A workaround to define an empty variant of a GraphQL union.
+  """
+  _: Boolean
+}
+
+"""
+System transaction to update the source of on-chain randomness.
+"""
+type RandomnessStateUpdateTransaction {
+  """
+  Epoch of the randomness state update transaction.
+  """
+  epoch: Int
+
+  """
+  Randomness round of the update.
+  """
+  randomnessRound: Int
+
+  """
+  Updated random bytes, Base64 encoded.
+  """
+  randomBytes: Base64
+
+  """
+  The initial version of the randomness object that it was shared at.
+  """
+  randomnessObjInitialSharedVersion: Int
+}
+
+"""
+A transaction that wanted to read a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
+"""
+type ReadConsensusStreamEnded {
+  """
+  The ID of the consensus-managed object.
+  """
+  address: SuiAddress
+
+  """
+  The sequence number associated with the consensus stream ending.
+  """
+  sequenceNumber: UInt53
+}
+
+"""
+A Move object that can be received in this transaction.
+"""
+type Receiving {
+  object: Object
+}
+
+"""
+Whether the currency is regulated or not.
+"""
+enum RegulatedState {
+  """
+  A `DenyCap` or a `RegulatedCoinMetadata` exists for this currency.
+  """
+  REGULATED
+
+  """
+  The currency was created without a deny list.
+  """
+  UNREGULATED
+}
+
+type SafeMode {
+  """
+  Whether safe mode was used for the last epoch change.
+  The system will retry a full epoch change on every epoch boundary and automatically reset this flag if so.
+  """
+  enabled: Boolean
+
+  """
+  Accumulated fees for computation and cost that have not been added to the various reward pools, because the full epoch change did not happen.
+  """
+  gasSummary: GasCostSummary
+}
+
+type ServiceConfig {
+  """
+  Maximum time in milliseconds spent waiting for a response from fullnode after issuing a transaction to execute. Note that the transaction may still succeed even in the case of a timeout. Transactions are idempotent, so a transaction that times out should be re-submitted until the network returns a definite response (success or failure, not timeout).
+  """
+  mutationTimeoutMs: Int
+
+  """
+  Maximum time in milliseconds that will be spent to serve one query request.
+  """
+  queryTimeoutMs: Int
+
+  """
+  Maximum depth of a GraphQL query that can be accepted by this service.
+  """
+  maxQueryDepth: Int
+
+  """
+  The maximum number of nodes (field names) the service will accept in a single query.
+  """
+  maxQueryNodes: Int
+
+  """
+  Maximum number of estimated output nodes in a GraphQL response.
+
+  The estimate is an upperbound of how many nodes there would be in the output assuming every requested field is present, paginated requests return full page sizes, and multi-get queries find all requested keys. Below is a worked example query:
+
+  ```graphql
+  |  0: query {                            # 514 = total
+  |  1:   checkpoint {                     # 1
+  |  2:     sequenceNumber                 # 1
+  |  3:   }
+  |  4:
+  |  5:   multiGetObjects([$a, $b, $c]) {  # 1 (* 3)
+  |  6:     address                        # 3
+  |  7:     digest                         # 3
+  |  8:   }
+  |  9:
+  | 10:   # default page size is 20
+  | 11:   transactions {                   # 1 (* 20)
+  | 12:     pageInfo {                     # 1
+  | 13:       hasNextPage                  # 1
+  | 14:       endCursor                    # 1
+  | 15:     }
+  | 16:
+  | 17:     nodes                          # 1
+  | 18:     {                              # 20
+  | 19:       digest                       # 20
+  | 20:       effects {                    # 20
+  | 21:         objectChanges(first: 10) { # 20 (* 10)
+  | 22:           nodes                    # 20
+  | 23:           {                        # 200
+  | 24:             address                # 200
+  | 25:           }
+  | 26:         }
+  | 27:       }
+  | 28:     }
+  | 29:   }
+  | 30: }
+  ```
+  """
+  maxOutputNodes: Int
+
+  """
+  Maximum size in bytes allowed for the `txBytes` and `signatures` parameters of an `executeTransaction` or `simulateTransaction` field, or the `bytes` and `signature` parameters of a `verifyZkLoginSignature` field.
+
+  This is cumulative across all matching fields in a single GraphQL request.
+  """
+  maxTransactionPayloadSize: Int
+
+  """
+  Maximum size in bytes of a single GraphQL request, excluding the elements covered by `maxTransactionPayloadSize`.
+  """
+  maxQueryPayloadSize: Int
+
+  """
+  Number of elements a paginated connection will return if a page size is not supplied.
+
+  Accepts `type` and `field` arguments which identify the connection that is being queried. If the field in question is paginated, its default page size is returned. If it does not exist or is not paginated, `null` is returned.
+  """
+  defaultPageSize(type: String!, field: String!): Int
+
+  """
+  Maximum number of elements that can be requested from a paginated connection. A request to fetch more elements will result in an error.
+
+  Accepts `type` and `field` arguments which identify the connection that is being queried. If the field in question is paginated, its max page size is returned. If it does not exist or is not paginated, `null` is returned.
+  """
+  maxPageSize(type: String!, field: String!): Int
+
+  """
+  Maximum number of elements that can be requested from a multi-get query. A request to fetch more keys will result in an error.
+  """
+  maxMultiGetSize: Int
+
+  """
+  Maximum amount of nesting among type arguments (type arguments nest when a type argument is itself generic and has arguments).
+  """
+  maxTypeArgumentDepth: Int
+
+  """
+  Maximum number of type parameters a type can have.
+  """
+  maxTypeArgumentWidth: Int
+
+  """
+  Maximum number of datatypes that need to be processed when calculating the layout of a single type.
+  """
+  maxTypeNodes: Int
+
+  """
+  Maximum nesting allowed in datatype fields when calculating the layout of a single type.
+  """
+  maxMoveValueDepth: Int
+
+  """
+  Maximum budget in bytes to spend when outputting a structured `MoveValue`.
+  """
+  maxMoveValueBound: Int
+
+  """
+  Maximum depth of nested field access supported in display outputs.
+  """
+  maxDisplayFieldDepth: Int
+
+  """
+  Maximum output size of a display output.
+  """
+  maxDisplayOutputSize: Int
+
+  """
+  Maximum output size of a disassembled MoveModule, in bytes.
+  """
+  maxDisassembledModuleSize: Int
+
+  """
+  Range of checkpoints for which data is available for a query type, field and optional filter. If filter is not provided, the strictest retention range for the query and type is returned.
+  """
+  availableRange(
+    type: String!
+    field: String
+    filters: [String!]
+  ): AvailableRange!
+}
+
+"""
+Object is shared, can be used by any address, and is mutable.
+"""
+type Shared {
+  """
+  The version at which the object became shared.
+  """
+  initialSharedVersion: UInt53
+}
+
+"""
+A Move object that's shared.
+"""
+type SharedInput {
+  """
+  The address of the shared object.
+  """
+  address: SuiAddress
+
+  """
+  The version that this object was shared at.
+  """
+  initialSharedVersion: UInt53
+
+  """
+  Controls whether the transaction block can reference the shared object as a mutable reference or by value.
+
+  This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
+  """
+  mutable: Boolean
+}
+
+"""
+The result of simulating a transaction, including the predicted effects, events, and any errors.
+"""
+type SimulationResult {
+  """
+  The predicted effects of the transaction if it were executed.
+
+  `None` if the simulation failed due to an error.
+  """
+  effects: TransactionEffects
+
+  """
+  The events that would be emitted if the transaction were executed.
+
+  `None` if the simulation failed or no events would be emitted.
+  """
+  events: [Event!]
+
+  """
+  The intermediate outputs for each command of the transaction simulation, including contents of mutated references and return values.
+  """
+  outputs: [CommandResult!]
+
+  """
+  Error message if the simulation failed.
+
+  `None` if the simulation was successful.
+  """
+  error: String
+}
+
+"""
+Splits off coins with denominations in `amounts` from `coin`, returning multiple results (as many as there are amounts.)
+"""
+type SplitCoinsCommand {
+  """
+  The coin to split.
+  """
+  coin: TransactionArgument
+
+  """
+  The denominations to split off from the coin.
+  """
+  amounts: [TransactionArgument!]!
+}
+
+"""
+Parameters that control the distribution of the stake subsidy.
+"""
+type StakeSubsidy {
+  """
+  SUI set aside for stake subsidies -- reduces over time as stake subsidies are paid out over time.
+  """
+  balance: BigInt
+
+  """
+  Number of times stake subsidies have been distributed.
+  Subsidies are distributed with other staking rewards, at the end of the epoch.
+  """
+  distributionCounter: Int
+
+  """
+  Amount of stake subsidy deducted from the balance per distribution -- decays over time.
+  """
+  currentDistributionAmount: BigInt
+
+  """
+  Maximum number of stake subsidy distributions that occur with the same distribution amount (before the amount is reduced).
+  """
+  periodLength: Int
+
+  """
+  Percentage of the current distribution amount to deduct at the end of the current subsidy period, expressed in basis points.
+  """
+  decreaseRate: Int
+}
+
+"""
+SUI set aside to account for objects stored on-chain.
+"""
+type StorageFund {
+  """
+  Sum of storage rebates of live objects on chain.
+  """
+  totalObjectStorageRebates: BigInt
+
+  """
+  The portion of the storage fund that will never be refunded through storage rebates.
+  The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
+  """
+  nonRefundableBalance: BigInt
+}
+
+"""
+System transaction for storing execution time observations.
+"""
+type StoreExecutionTimeObservationsTransaction {
+  """
+  A workaround to define an empty variant of a GraphQL union.
+  """
+  _: Boolean
+}
+
+"""
+String containing 32 byte hex-encoded address, with a leading '0x'. Leading zeroes can be omitted on input but will always appear in outputs (SuiAddress in output is guaranteed to be 66 characters long).
+"""
+scalar SuiAddress
+
+"""
+Future behavior of a currency's supply.
+"""
+enum SupplyState {
+  """
+  The supply can only decrease.
+  """
+  BURN_ONLY
+
+  """
+  The supply can neither increase nor decrease.
+  """
+  FIXED
+}
+
+"""
+Details of the system that are decided during genesis.
+"""
+type SystemParameters {
+  """
+  Target duration of an epoch, in milliseconds.
+  """
+  durationMs: BigInt
+
+  """
+  The epoch at which stake subsidies start being paid out.
+  """
+  stakeSubsidyStartEpoch: UInt53
+
+  """
+  The minimum number of active validators that the system supports.
+  """
+  minValidatorCount: Int
+
+  """
+  The maximum number of active validators that the system supports.
+  """
+  maxValidatorCount: Int
+
+  """
+  Minimum stake needed to become a new validator.
+  """
+  minValidatorJoiningStake: BigInt
+
+  """
+  Validators with stake below this threshold will enter the grace period (see `validatorLowStakeGracePeriod`), after which they are removed from the active validator set.
+  """
+  validatorLowStakeThreshold: BigInt
+
+  """
+  Validators with stake below this threshold will be removed from the active validator set at the next epoch boundary, without a grace period.
+  """
+  validatorVeryLowStakeThreshold: BigInt
+
+  """
+  The number of epochs that a validator has to recover from having less than `validatorLowStakeThreshold` stake.
+  """
+  validatorLowStakeGracePeriod: BigInt
+}
+
+"""
+Description of a transaction, the unit of activity on Sui.
+"""
+type Transaction {
+  """
+  A 32-byte hash that uniquely identifies the transaction contents, encoded in Base58.
+  """
+  digest: String!
+
+  """
+  The results to the chain of executing this transaction.
+  """
+  effects: TransactionEffects
+
+  """
+  The type of this transaction as well as the commands and/or parameters comprising the transaction of this kind.
+  """
+  kind: TransactionKind
+
+  """
+  This field is set by senders of a transaction block. It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid. By default, there is no deadline for when a transaction must execute.
+  """
+  expiration: Epoch
+
+  """
+  The gas input field provides information on what objects were used as gas as well as the owner of the gas object(s) and information on the gas price and budget.
+  """
+  gasInput: GasInput
+
+  """
+  The address corresponding to the public key that signed this transaction. System transactions do not have senders.
+  """
+  sender: Address
+
+  """
+  The Base64-encoded BCS serialization of this transaction, as a `TransactionData`.
+  """
+  transactionBcs: Base64
+
+  """
+  User signatures for this transaction.
+  """
+  signatures: [UserSignature!]!
+}
+
+"""
+An argument to a programmable transaction command.
+"""
+union TransactionArgument = GasCoin | Input | TxResult
+
+type TransactionConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [TransactionEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [Transaction!]!
+}
+
+"""
+An edge in a connection.
+"""
+type TransactionEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Transaction!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+The results of executing a transaction.
+"""
+type TransactionEffects {
+  """
+  A 32-byte hash that uniquely identifies the transaction contents, encoded in Base58.
+
+  Note that this is different from the execution digest, which is the unique hash of the transaction effects.
+  """
+  digest: String!
+
+  """
+  The transaction that ran to produce these effects.
+  """
+  transaction: Transaction
+
+  """
+  The checkpoint this transaction was finalized in.
+  """
+  checkpoint: Checkpoint
+
+  """
+  Whether the transaction executed successfully or not.
+  """
+  status: ExecutionStatus
+
+  """
+  The latest version of all objects (apart from packages) that have been created or modified by this transaction, immediately following this transaction.
+  """
+  lamportVersion: UInt53
+
+  """
+  Rich execution error information for failed transactions.
+  """
+  executionError: ExecutionError
+
+  """
+  Timestamp corresponding to the checkpoint this transaction was finalized in.
+  """
+  timestamp: DateTime
+
+  """
+  The epoch this transaction was finalized in.
+  """
+  epoch: Epoch
+
+  """
+  Events emitted by this transaction.
+  """
+  events(first: Int, after: String, last: Int, before: String): EventConnection
+
+  """
+  The effect this transaction had on the balances (sum of coin values per coin type) of addresses and objects.
+  """
+  balanceChanges(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): BalanceChangeConnection
+
+  """
+  The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
+  """
+  effectsBcs: Base64
+
+  """
+  A 32-byte hash that uniquely identifies the effects contents, encoded in Base58.
+  """
+  effectsDigest: String
+
+  """
+  The before and after state of objects that were modified by this transaction.
+  """
+  objectChanges(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): ObjectChangeConnection
+
+  """
+  Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+  """
+  gasEffects: GasEffects
+
+  """
+  The unchanged consensus-managed objects that were referenced by this transaction.
+  """
+  unchangedConsensusObjects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): UnchangedConsensusObjectConnection
+
+  """
+  Transactions whose outputs this transaction depends upon.
+  """
+  dependencies(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): TransactionConnection
+}
+
+input TransactionFilter {
+  """
+  Filter to transactions that occurred strictly after the given checkpoint.
+  """
+  afterCheckpoint: UInt53
+
+  """
+  Filter to transactions in the given checkpoint.
+  """
+  atCheckpoint: UInt53
+
+  """
+  Filter to transaction that occurred strictly before the given checkpoint.
+  """
+  beforeCheckpoint: UInt53
+
+  """
+  Filter transactions by move function called. Calls can be filtered by the `package`, `package::module`, or the `package::module::name` of their function.
+  """
+  function: String
+
+  """
+  An input filter selecting for either system or programmable transactions.
+  """
+  kind: TransactionKindInput
+
+  """
+  Limit to transactions that interacted with the given address.
+  The address could be a sender, sponsor, or recipient of the transaction.
+  """
+  affectedAddress: SuiAddress
+
+  """
+  Limit to transactions that interacted with the given object.
+  The object could have been created, read, modified, deleted, wrapped, or unwrapped by the transaction.
+  Objects that were passed as a `Receiving` input are not considered to have been affected by a transaction unless they were actually received.
+  """
+  affectedObject: SuiAddress
+
+  """
+  Limit to transactions that were sent by the given address.
+  """
+  sentAddress: SuiAddress
+}
+
+"""
+Input argument to a Programmable Transaction Block (PTB) command.
+"""
+union TransactionInput = Pure | OwnedOrImmutable | SharedInput | Receiving
+
+type TransactionInputConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [TransactionInputEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [TransactionInput!]!
+}
+
+"""
+An edge in a connection.
+"""
+type TransactionInputEdge {
+  """
+  The item at the end of the edge
+  """
+  node: TransactionInput!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+Different types of transactions that can be executed on the Sui network.
+"""
+union TransactionKind =
+    GenesisTransaction
+  | ConsensusCommitPrologueTransaction
+  | ChangeEpochTransaction
+  | RandomnessStateUpdateTransaction
+  | AuthenticatorStateUpdateTransaction
+  | EndOfEpochTransaction
+  | ProgrammableTransaction
+  | ProgrammableSystemTransaction
+
+"""
+An input filter selecting for either system or programmable transactions.
+"""
+enum TransactionKindInput {
+  """
+  A system transaction can be one of several types of transactions.
+  See [unions/transaction-block-kind] for more details.
+  """
+  SYSTEM_TX
+
+  """
+  A user submitted transaction block.
+  """
+  PROGRAMMABLE_TX
+}
+
+"""
+Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public transfer) and must not be previously immutable or shared.
+"""
+type TransferObjectsCommand {
+  """
+  The objects to transfer.
+  """
+  inputs: [TransactionArgument!]!
+
+  """
+  The address to transfer to.
+  """
+  address: TransactionArgument
+}
+
+"""
+The result of another command.
+"""
+type TxResult {
+  """
+  The index of the command that produced this result.
+  """
+  cmd: Int
+
+  """
+  For nested results, the index within the result.
+  """
+  ix: Int
+}
+
+"""
+Information about which previous versions of a package introduced its types.
+"""
+type TypeOrigin {
+  """
+  Module defining the type.
+  """
+  module: String
+
+  """
+  Name of the struct.
+  """
+  struct: String
+
+  """
+  The storage ID of the package that first defined this type.
+  """
+  definingId: SuiAddress
+}
+
+"""
+An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.
+"""
+scalar UInt53
+
+"""
+Details pertaining to consensus-managed objects that are referenced by but not changed by a transaction.
+"""
+union UnchangedConsensusObject =
+    ConsensusObjectRead
+  | MutateConsensusStreamEnded
+  | ReadConsensusStreamEnded
+  | ConsensusObjectCancelled
+  | PerEpochConfig
+
+type UnchangedConsensusObjectConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [UnchangedConsensusObjectEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [UnchangedConsensusObject!]!
+}
+
+"""
+An edge in a connection.
+"""
+type UnchangedConsensusObjectEdge {
+  """
+  The item at the end of the edge
+  """
+  node: UnchangedConsensusObject!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+Upgrades a Move Package.
+"""
+type UpgradeCommand {
+  """
+  Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+  """
+  modules: [Base64!]
+
+  """
+  IDs of the transitive dependencies of the package to be published.
+  """
+  dependencies: [SuiAddress!]
+
+  """
+  ID of the package being upgraded.
+  """
+  currentPackage: SuiAddress
+
+  """
+  The `UpgradeTicket` authorizing the upgrade.
+  """
+  upgradeTicket: TransactionArgument
+}
+
+type UserSignature {
+  """
+  The signature bytes, Base64-encoded.
+  For simple signatures: flag || signature || pubkey
+  For complex signatures: flag || bcs_serialized_struct
+  """
+  signatureBytes: Base64
+}
+
+type Validator implements IAddressable {
+  """
+  The validator's address.
+  """
+  address: SuiAddress!
+
+  """
+  Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+
+  If the address does not own any coins of that type, a balance of zero is returned.
+  """
+  balance(coinType: String!): Balance
+
+  """
+  Total balance across coins owned by this address, grouped by coin type.
+  """
+  balances(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): BalanceConnection
+
+  """
+  The domain explicitly configured as the default SuiNS name for this address.
+  """
+  defaultSuinsName: String
+
+  """
+  Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+
+  Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+  If the address does not own any coins of a given type, a balance of zero is returned for that type.
+  """
+  multiGetBalances(keys: [String!]!): [Balance!]
+
+  """
+  Objects owned by this object, optionally filtered by type.
+  """
+  objects(
+    first: Int
+    after: String
+    last: Int
+    before: String
+    filter: ObjectFilter
+  ): MoveObjectConnection
+
+  """
+  Validator's set of credentials such as public keys, network addresses and others.
+  """
+  credentials: ValidatorCredentials
+
+  """
+  Validator's set of credentials for the next epoch.
+  """
+  nextEpochCredentials: ValidatorCredentials
+
+  """
+  Validator's name.
+  """
+  name: String
+
+  """
+  Validator's description.
+  """
+  description: String
+
+  """
+  Validator's url containing their custom image.
+  """
+  imageUrl: String
+
+  """
+  Validator's homepage URL.
+  """
+  projectUrl: String
+
+  """
+  The validator's current valid `Cap` object. Validators can delegate the operation ability to another address.
+  The address holding this `Cap` object can then update the reference gas price and tallying rule on behalf of the validator.
+  """
+  operationCap: MoveObject
+
+  """
+  The ID of this validator's `0x3::staking_pool::StakingPool`.
+  """
+  stakingPoolId: SuiAddress!
+
+  """
+  A wrapped object containing the validator's exchange rates. This is a table from epoch number to `PoolTokenExchangeRate` value.
+  The exchange rate is used to determine the amount of SUI tokens that each past SUI staker can withdraw in the future.
+  """
+  exchangeRatesTable: Address
+
+  """
+  Number of exchange rates in the table.
+  """
+  exchangeRatesSize: UInt53
+
+  """
+  The epoch at which this pool became active.
+  """
+  stakingPoolActivationEpoch: UInt53
+
+  """
+  The total number of SUI tokens in this pool.
+  """
+  stakingPoolSuiBalance: BigInt
+
+  """
+  The epoch stake rewards will be added here at the end of each epoch.
+  """
+  rewardsPool: BigInt
+
+  """
+  Total number of pool tokens issued by the pool.
+  """
+  poolTokenBalance: BigInt
+
+  """
+  Pending stake amount for this epoch.
+  """
+  pendingStake: BigInt
+
+  """
+  Pending stake withdrawn during the current epoch, emptied at epoch boundaries.
+  """
+  pendingTotalSuiWithdraw: BigInt
+
+  """
+  Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
+  """
+  pendingPoolTokenWithdraw: BigInt
+
+  """
+  The voting power of this validator in basis points (e.g., 100 = 1% voting power).
+  """
+  votingPower: Int
+
+  """
+  The reference gas price for this epoch.
+  """
+  gasPrice: BigInt
+
+  """
+  The fee charged by the validator for staking services.
+  """
+  commissionRate: Int
+
+  """
+  The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
+  """
+  nextEpochStake: BigInt
+
+  """
+  The validator's gas price quote for the next epoch.
+  """
+  nextEpochGasPrice: BigInt
+
+  """
+  The proposed next epoch fee for the validator's staking services.
+  """
+  nextEpochCommissionRate: Int
+
+  """
+  The number of epochs for which this validator has been below the low stake threshold.
+  """
+  atRisk: UInt53
+
+  """
+  Other validators this validator has reported.
+  """
+  reportRecords(
+    first: Int
+    before: String
+    last: Int
+    after: String
+  ): ValidatorConnection
+}
+
+type ValidatorAggregatedSignature {
+  """
+  The epoch when this aggregate signature was produced.
+  """
+  epoch: Epoch
+
+  """
+  The Base64 encoded BLS12381 aggregated signature.
+  """
+  signature: Base64
+
+  """
+  The indexes of validators that contributed to this signature.
+  """
+  signersMap: [Int!]!
+}
+
+type ValidatorConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [ValidatorEdge!]!
+
+  """
+  A list of nodes.
+  """
+  nodes: [Validator!]!
+}
+
+"""
+The credentials related fields associated with a validator.
+"""
+type ValidatorCredentials {
+  protocolPubKey: Base64
+  networkPubKey: Base64
+  workerPubKey: Base64
+  proofOfPossession: Base64
+  netAddress: String
+  p2PAddress: String
+  primaryAddress: String
+  workerAddress: String
+}
+
+"""
+An edge in a connection.
+"""
+type ValidatorEdge {
+  """
+  The item at the end of the edge
+  """
+  node: Validator!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
+"""
+Representation of `0x3::validator_set::ValidatorSet`.
+"""
+type ValidatorSet {
+  """
+  The current list of active validators.
+  """
+  activeValidators(
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): ValidatorConnection
+
+  """
+  Object ID of the `Table` storing the inactive staking pools.
+  """
+  inactivePoolsId: SuiAddress
+
+  """
+  Size of the inactive pools `Table`.
+  """
+  inactivePoolsSize: Int
+
+  """
+  Object ID of the wrapped object `TableVec` storing the pending active validators.
+  """
+  pendingActiveValidatorsId: SuiAddress
+
+  """
+  Size of the pending active validators table.
+  """
+  pendingActiveValidatorsSize: Int
+
+  """
+  Validators that are pending removal from the active validator set, expressed as indices in to `activeValidators`.
+  """
+  pendingRemovals: [Int!]
+
+  """
+  Object ID of the `Table` storing the mapping from staking pool ids to the addresses of the corresponding validators.
+  This is needed because a validator's address can potentially change but the object ID of its pool will not.
+  """
+  stakingPoolMappingsId: SuiAddress
+
+  """
+  Size of the stake pool mappings `Table`.
+  """
+  stakingPoolMappingsSize: Int
+
+  """
+  Total amount of stake for all active validators at the beginning of the epoch.
+  """
+  totalStake: BigInt
+
+  """
+  Object ID of the `Table` storing the validator candidates.
+  """
+  validatorCandidatesId: SuiAddress
+
+  """
+  Size of the validator candidates `Table`.
+  """
+  validatorCandidatesSize: Int
+}
+
+"""
+Filter for paginating the history of an Object or MovePackage.
+"""
+input VersionFilter {
+  """
+  Filter to versions that are strictly newer than this one, defaults to fetching from the earliest version known to this RPC (this could be the initial version, or some later version if the initial version has been pruned).
+  """
+  afterVersion: UInt53
+
+  """
+  Filter to versions that are strictly older than this one, defaults to fetching up to the latest version (inclusive).
+  """
+  beforeVersion: UInt53
+}
+
+"""
+An enum that specifies the intent scope to be used to parse the bytes for signature verification.
+"""
+enum ZkLoginIntentScope {
+  """
+  Indicates that the bytes are to be parsed as transaction data bytes.
+  """
+  TRANSACTION_DATA
+
+  """
+  Indicates that the bytes are to be parsed as a personal message.
+  """
+  PERSONAL_MESSAGE
+}
+
+"""
+The result of the zkLogin signature verification.
+"""
+type ZkLoginVerifyResult {
+  """
+  The boolean result of the verification. If true, errors should be empty.
+  """
+  success: Boolean
+
+  """
+  The error field capture reasons why the signature could not be verified, assuming the inputs are valid and there are no internal errors.
+  """
+  error: String
+}

--- a/sdk/src/events/mod.rs
+++ b/sdk/src/events/mod.rs
@@ -1,0 +1,606 @@
+use {
+    crate::{sui, types::*, ToolFqn},
+    anyhow::{bail, Result},
+    serde::{Deserialize, Serialize},
+};
+
+mod fetching;
+mod graphql;
+mod parsing;
+
+pub use {fetching::*, graphql::*, parsing::*};
+
+/// Struct holding the Sui event ID, the event generic arguments and the data
+/// as one of [NexusEventKind].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NexusEvent {
+    /// The event transaction digest and event sequence.
+    pub id: (sui::types::Digest, u64),
+    /// If the `T in NexusEvent<T>` is also a generic, this field holds the
+    /// generic type. Note that this can be nested indefinitely.
+    pub generics: Vec<sui::types::TypeTag>,
+    /// The event data.
+    pub data: NexusEventKind,
+}
+
+macro_rules! events {
+    (
+        $(
+            $struct_name:ident => $variant:ident, $name:expr
+        ),* $(,)?
+    ) => {
+
+        // == enum NexusEventKind ==
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[serde(tag = "_nexus_event_type", content = "event")]
+        pub enum NexusEventKind {
+            $(
+                #[serde(rename = $name)]
+                $variant($struct_name),
+            )*
+        }
+
+        impl NexusEventKind {
+            /// Returns the name of the event kind as a string.
+            pub fn name(&self) -> String {
+                match self {
+                    $(
+                        NexusEventKind::$variant(_) => stringify!($struct_name).to_string(),
+                    )*
+                }
+            }
+        }
+
+        // == Parsing from BCS ==
+
+        pub(super) fn parse_bcs(name: &str, bytes: &[u8]) -> Result<NexusEventKind> {
+            #[derive(Deserialize)]
+            struct Wrapper<T> {
+                event: T,
+            }
+
+            match name {
+                $(
+                    stringify!($struct_name) => {
+                        let obj: Wrapper<$struct_name> = bcs::from_bytes(bytes)?;
+                        Ok(NexusEventKind::$variant(obj.event))
+                    }
+                )*
+                _ => bail!("Unknown event: {}", name),
+            }
+        }
+    };
+}
+
+// TODO: @david to re-implement or to simplify by removing generic.
+// #[derive(Clone, Debug, Serialize, Deserialize)]
+// pub struct RequestScheduledExecution<T>
+// where
+//     T: Clone + Serialize + DeserializeOwned,
+// {
+//     pub request: T,
+//     #[serde(
+//         deserialize_with = "deserialize_sui_u64",
+//         serialize_with = "serialize_sui_u64"
+//     )]
+//     pub priority: u64,
+//     #[serde(
+//         deserialize_with = "deserialize_sui_u64",
+//         serialize_with = "serialize_sui_u64"
+//     )]
+//     pub request_ms: u64,
+//     #[serde(
+//         deserialize_with = "deserialize_sui_u64",
+//         serialize_with = "serialize_sui_u64"
+//     )]
+//     pub start_ms: u64,
+//     #[serde(
+//         deserialize_with = "deserialize_sui_u64",
+//         serialize_with = "serialize_sui_u64"
+//     )]
+//     pub deadline_ms: u64,
+// }
+
+// Enumeration with all available events coming from the on-chain part of
+// Nexus. Also includes BCS parsing implementations.
+events! {
+
+    // TODO: @david to re-implement or to simplify by removing generic.
+    // RequestScheduledExecution => Scheduled, "RequestScheduledExecution",
+
+    OccurrenceScheduledEvent => OccurrenceScheduled, "OccurrenceScheduledEvent",
+    RequestWalkExecutionEvent => RequestWalkExecution, "RequestWalkExecutionEvent",
+    AnnounceInterfacePackageEvent => AnnounceInterfacePackage, "AnnounceInterfacePackageEvent",
+    OffChainToolRegisteredEvent => OffChainToolRegistered, "OffChainToolRegisteredEvent",
+    OnChainToolRegisteredEvent => OnChainToolRegistered, "OnChainToolRegisteredEvent",
+    ToolUnregisteredEvent => ToolUnregistered, "ToolUnregisteredEvent",
+    WalkAdvancedEvent => WalkAdvanced, "WalkAdvancedEvent",
+    WalkFailedEvent => WalkFailed, "WalkFailedEvent",
+    EndStateReachedEvent => EndStateReached, "EndStateReachedEvent",
+    ExecutionFinishedEvent => ExecutionFinished, "ExecutionFinishedEvent",
+    MissedOccurrenceEvent => MissedOccurrence, "MissedOccurrenceEvent",
+    TaskCreatedEvent => TaskCreated, "TaskCreatedEvent",
+    TaskPausedEvent => TaskPaused, "TaskPausedEvent",
+    TaskResumedEvent => TaskResumed, "TaskResumedEvent",
+    TaskCanceledEvent => TaskCanceled, "TaskCanceledEvent",
+    OccurrenceConsumedEvent => OccurrenceConsumed, "OccurrenceConsumedEvent",
+    PeriodicScheduleConfiguredEvent => PeriodicScheduleConfigured, "PeriodicScheduleConfiguredEvent",
+    FoundingLeaderCapCreatedEvent => FoundingLeaderCapCreated, "FoundingLeaderCapCreatedEvent",
+    GasSettlementUpdateEvent => GasSettlementUpdate, "GasSettlementUpdateEvent",
+    PreKeyVaultCreatedEvent => PreKeyVaultCreated, "PreKeyVaultCreatedEvent",
+    PreKeyRequestedEvent => PreKeyRequested, "PreKeyRequestedEvent",
+    PreKeyFulfilledEvent => PreKeyFulfilled, "PreKeyFulfilledEvent",
+    PreKeyAssociatedEvent => PreKeyAssociated, "PreKeyAssociatedEvent",
+    DAGCreatedEvent => DAGCreated, "DAGCreatedEvent",
+
+    // These events are unused for now.
+    // "ToolRegistryCreated" => ToolRegistryCreated(serde_json::Value),
+    // "DAGVertexAdded" => DAGVertexAdded(serde_json::Value),
+    // "DAGEdgeAdded" => DAGEdgeAdded(serde_json::Value),
+    // "DAGOutputAdded" => DAGOutputAdded(serde_json::Value),
+    // "DAGEntryVertexInputPortAdded" => DAGEntryVertexInputPortAdded(serde_json::Value),
+    // "DAGDefaultValueAdded" => DAGDefaultValueAdded(serde_json::Value),
+    // "LeaderClaimedGas" => LeaderClaimedGas(serde_json::Value),
+    // "AllowedOwnerAdded" => AllowedOwnerAdded(serde_json::Value),
+    // "AllowedOwnerRemoved" => AllowedOwnerRemoved(serde_json::Value),
+}
+
+// == Event definitions ==
+
+/// Fired by the on-chain part of Nexus when a DAG vertex execution is
+/// requested.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RequestWalkExecutionEvent {
+    pub dag: sui::types::Address,
+    pub execution: sui::types::Address,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub walk_index: u64,
+    pub next_vertex: RuntimeVertex,
+    pub evaluations: sui::types::Address,
+    /// This field defines the package ID, module and name of the Agent that
+    /// holds the DAG. Used to confirm the tool evaluation with the Agent.
+    pub worksheet_from_type: TypeName,
+}
+
+/// Fired via the Nexus `interface` package when a new Agent is registered.
+/// Provides the agent's interface so that we can invoke
+/// `confirm_tool_eval_for_walk` on it.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AnnounceInterfacePackageEvent {
+    pub shared_objects: Vec<sui::types::Address>,
+}
+
+/// Fired by the Nexus Workflow when a new off-chain tool is registered so that
+/// the Leader can also register it in Redis. This way the Leader knows how and
+/// where to evaluate the tool.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OffChainToolRegisteredEvent {
+    pub registry: sui::types::Address,
+    pub tool: sui::types::Address,
+    /// The tool domain, name and version. See [ToolFqn] for more information.
+    pub fqn: ToolFqn,
+    #[serde(
+        deserialize_with = "deserialize_bytes_to_url",
+        serialize_with = "serialize_url_to_bytes"
+    )]
+    pub url: reqwest::Url,
+    #[serde(
+        deserialize_with = "deserialize_bytes_to_json_value",
+        serialize_with = "serialize_json_value_to_bytes"
+    )]
+    pub input_schema: serde_json::Value,
+    #[serde(
+        deserialize_with = "deserialize_bytes_to_json_value",
+        serialize_with = "serialize_json_value_to_bytes"
+    )]
+    pub output_schema: serde_json::Value,
+}
+
+/// Fired by the Nexus Workflow when a new on-chain tool is registered so that
+/// the Leader can also register it in Redis. This way the Leader knows how and
+/// where to evaluate the tool.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OnChainToolRegisteredEvent {
+    /// [ID] of [ToolRegistry].
+    pub registry: sui::types::Address,
+    /// New [ID] of the [OnChainTool].
+    pub tool: sui::types::Address,
+    /// When the tool was registered.
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub registered_at_ms: u64,
+    /// The tool domain, name and version. See [ToolFqn] for more information.
+    pub fqn: ToolFqn,
+    /// The address of the published package.
+    pub package_address: sui::types::Address,
+    /// Module name.
+    pub module_name: String,
+    /// The witness object ID that proves the tool's identity.
+    pub witness_id: sui::types::Address,
+    /// Arguments to the execute function.
+    #[serde(
+        deserialize_with = "deserialize_bytes_to_json_value",
+        serialize_with = "serialize_json_value_to_bytes"
+    )]
+    pub input_schema: serde_json::Value,
+    /// Output schema of the execute function.
+    #[serde(
+        deserialize_with = "deserialize_bytes_to_json_value",
+        serialize_with = "serialize_json_value_to_bytes"
+    )]
+    pub output_schema: serde_json::Value,
+    /// Description of the tool.
+    #[serde(
+        deserialize_with = "deserialize_bytes_to_string",
+        serialize_with = "serialize_string_to_bytes"
+    )]
+    pub description: String,
+}
+
+/// Fired by the Nexus Workflow when a tool is unregistered. The Leader should
+/// remove the tool definition from its Redis registry.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ToolUnregisteredEvent {
+    pub tool: sui::types::Address,
+    /// The tool domain, name and version. See [ToolFqn] for more information.
+    pub fqn: ToolFqn,
+}
+
+/// Fired by the Nexus Workflow when a walk has advanced. This event is used to
+/// inspect DAG execution process.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct WalkAdvancedEvent {
+    pub dag: sui::types::Address,
+    pub execution: sui::types::Address,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub walk_index: u64,
+    /// Which vertex was just executed.
+    pub vertex: RuntimeVertex,
+    /// Which output variant was evaluated.
+    pub variant: TypeName,
+    /// What data is associated with the variant.
+    pub variant_ports_to_data: PortsData,
+}
+
+/// Fired by the Nexus Workflow when a walk has failed.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct WalkFailedEvent {
+    pub dag: sui::types::Address,
+    pub execution: sui::types::Address,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub walk_index: u64,
+    /// Which vertex was being executed when the failure happened.
+    pub vertex: RuntimeVertex,
+    /// The error message associated with the failure.
+    pub reason: String,
+}
+
+/// Fired by the Nexus Workflow when a walk has halted in an end state. This
+/// event is used to inspect DAG execution process.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EndStateReachedEvent {
+    pub dag: sui::types::Address,
+    pub execution: sui::types::Address,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub walk_index: u64,
+    /// Which vertex was just executed.
+    pub vertex: RuntimeVertex,
+    /// Which output variant was evaluated.
+    pub variant: TypeName,
+    /// What data is associated with the variant.
+    pub variant_ports_to_data: PortsData,
+}
+
+/// Fired by the Nexus Workflow when all walks have halted in their end states
+/// and there is no more work to be done. This event is used to inspect DAG
+/// execution process.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ExecutionFinishedEvent {
+    pub dag: sui::types::Address,
+    pub execution: sui::types::Address,
+    pub has_any_walk_failed: bool,
+    pub has_any_walk_succeeded: bool,
+}
+
+/// Fired when a scheduler occurrence is enqueued (wrapped in `RequestScheduledExecution`).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OccurrenceScheduledEvent {
+    pub task: sui::types::Address,
+    pub generator: PolicySymbol,
+}
+
+/// Emitted when a scheduled occurrence misses its deadline and is pruned.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MissedOccurrenceEvent {
+    pub task: sui::types::Address,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub start_time_ms: u64,
+    #[serde(
+        deserialize_with = "deserialize_sui_option_u64",
+        serialize_with = "serialize_sui_option_u64"
+    )]
+    pub deadline_ms: Option<u64>,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub pruned_at: u64,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub gas_price: u64,
+    pub generator: PolicySymbol,
+}
+
+/// Emitted after a scheduler task object is created.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TaskCreatedEvent {
+    pub task: sui::types::Address,
+    pub owner: sui::types::Address,
+}
+
+/// Emitted when scheduling for a task is paused.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TaskPausedEvent {
+    pub task: sui::types::Address,
+}
+
+/// Emitted when scheduling for a task is resumed.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TaskResumedEvent {
+    pub task: sui::types::Address,
+}
+
+/// Emitted when scheduling for a task is canceled.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TaskCanceledEvent {
+    pub task: sui::types::Address,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub cleared_occurrences: u64,
+    pub had_periodic: bool,
+}
+
+/// Emitted whenever a pending occurrence is consumed for execution.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OccurrenceConsumedEvent {
+    pub task: sui::types::Address,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub start_time_ms: u64,
+    #[serde(
+        deserialize_with = "deserialize_sui_option_u64",
+        serialize_with = "serialize_sui_option_u64"
+    )]
+    pub deadline_ms: Option<u64>,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub gas_price: u64,
+    pub generator: PolicySymbol,
+    #[serde(
+        deserialize_with = "deserialize_sui_u64",
+        serialize_with = "serialize_sui_u64"
+    )]
+    pub executed_at: u64,
+}
+
+/// Emitted whenever the periodic schedule is configured or cleared.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PeriodicScheduleConfiguredEvent {
+    pub task: sui::types::Address,
+    #[serde(
+        deserialize_with = "deserialize_sui_option_u64",
+        serialize_with = "serialize_sui_option_u64"
+    )]
+    pub period_ms: Option<u64>,
+    #[serde(
+        deserialize_with = "deserialize_sui_option_u64",
+        serialize_with = "serialize_sui_option_u64"
+    )]
+    pub deadline_offset_ms: Option<u64>,
+    #[serde(
+        deserialize_with = "deserialize_sui_option_u64",
+        serialize_with = "serialize_sui_option_u64"
+    )]
+    pub max_iterations: Option<u64>,
+    #[serde(
+        deserialize_with = "deserialize_sui_option_u64",
+        serialize_with = "serialize_sui_option_u64"
+    )]
+    pub generated: Option<u64>,
+    #[serde(
+        deserialize_with = "deserialize_sui_option_u64",
+        serialize_with = "serialize_sui_option_u64"
+    )]
+    pub gas_price: Option<u64>,
+    #[serde(
+        deserialize_with = "deserialize_sui_option_u64",
+        serialize_with = "serialize_sui_option_u64"
+    )]
+    pub last_generated_start_ms: Option<u64>,
+}
+
+/// Fired by the Nexus Workflow when a new founding LeaderCap is created.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct FoundingLeaderCapCreatedEvent {
+    pub leader_cap: sui::types::Address,
+    pub network: sui::types::Address,
+}
+
+/// Fired by the Gas service when the gas settlement is updated. This event is
+/// used to determine whether a tool invocation was paid for by the caller.
+/// Combination of `execution` and `vertex` uniquely identifies the tool
+/// invocation.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GasSettlementUpdateEvent {
+    pub execution: sui::types::Address,
+    pub tool_fqn: ToolFqn,
+    pub vertex: RuntimeVertex,
+    pub was_settled: bool,
+}
+
+/// Fired when the leader claims gas from a user's budget.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LeaderClaimedGasEvent {
+    pub network: sui::types::Address,
+    pub amount: u64,
+    /// Optional reason for auditing purposes.
+    #[serde(default)]
+    pub purpose: String,
+}
+
+/// Fired by the Nexus Workflow when a new pre key vault is created. This happens
+/// on initial network setup.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PreKeyVaultCreatedEvent {
+    pub vault: sui::types::Address,
+    pub crypto_cap: sui::types::Address,
+}
+
+/// Fired by the Nexus Workflow when a pre key is requested. The pre key bytes
+/// are still empty at this point and will be fulfilled by the leader.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PreKeyRequestedEvent {
+    /// The address of the user that requested the pre key.
+    pub requested_by: sui::types::Address,
+}
+
+/// Fired by the Nexus Workflow when a pre key request is fulfilled by the
+/// leader. Carries the pending pre key bytes that the user can then associate.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PreKeyFulfilledEvent {
+    /// The address of the user that requested the pre key.
+    pub requested_by: sui::types::Address,
+    /// Bytes of the fulfilled pre key.
+    pub pre_key_bytes: Vec<u8>,
+}
+
+/// Fired by the Nexus Workflow when a pre key is associated with a user.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PreKeyAssociatedEvent {
+    /// The address of the user the pre key is associated with.
+    pub claimed_by: sui::types::Address,
+    /// Bytes of the pre key.
+    pub pre_key: Vec<u8>,
+    /// Bytes of the initial message.
+    pub initial_message: Vec<u8>,
+}
+
+/// Fired by the Nexus Workflow when a new DAG is created.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DAGCreatedEvent {
+    /// Address of the created DAG.
+    pub dag: sui::types::Address,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    events!(
+        DummyEvent => Dummy, "DummyEvent",
+        AnotherEvent => Another, "AnotherEvent",
+    );
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    pub struct DummyEvent {
+        pub value: u32,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    pub struct AnotherEvent {
+        pub text: String,
+    }
+
+    #[test]
+    fn test_nexus_event_kind_name_helper() {
+        let dummy = DummyEvent { value: 42 };
+        let another = AnotherEvent {
+            text: "hello".to_string(),
+        };
+
+        let kind_dummy = NexusEventKind::Dummy(dummy.clone());
+        let kind_another = NexusEventKind::Another(another.clone());
+
+        assert_eq!(kind_dummy.name(), "DummyEvent");
+        assert_eq!(kind_another.name(), "AnotherEvent");
+    }
+
+    #[test]
+    fn test_nexus_event_kind_enum_generation() {
+        let dummy = DummyEvent { value: 1 };
+        let another = AnotherEvent {
+            text: "abc".to_string(),
+        };
+
+        let kind_dummy = NexusEventKind::Dummy(dummy.clone());
+        let kind_another = NexusEventKind::Another(another.clone());
+
+        match kind_dummy {
+            NexusEventKind::Dummy(ev) => assert_eq!(ev, dummy),
+            _ => panic!("Expected Dummy variant"),
+        }
+
+        match kind_another {
+            NexusEventKind::Another(ev) => assert_eq!(ev, another),
+            _ => panic!("Expected Another variant"),
+        }
+    }
+
+    #[test]
+    fn test_nexus_event_kind_bcs_deser() {
+        let dummy = DummyEvent { value: 99 };
+        let another = AnotherEvent {
+            text: "xyz".to_string(),
+        };
+
+        let dummy_bytes = bcs::to_bytes(&dummy).unwrap();
+        let another_bytes = bcs::to_bytes(&another).unwrap();
+
+        let parsed_dummy = parse_bcs("DummyEvent", &dummy_bytes).unwrap();
+        let parsed_another = parse_bcs("AnotherEvent", &another_bytes).unwrap();
+
+        match parsed_dummy {
+            NexusEventKind::Dummy(ev) => assert_eq!(ev, dummy),
+            _ => panic!("Expected Dummy variant"),
+        }
+
+        match parsed_another {
+            NexusEventKind::Another(ev) => assert_eq!(ev, another),
+            _ => panic!("Expected Another variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_bcs_unknown_event() {
+        let dummy = DummyEvent { value: 123 };
+        let bytes = bcs::to_bytes(&dummy).unwrap();
+        let result = parse_bcs("UnknownEvent", &bytes);
+        assert!(result.is_err());
+    }
+}

--- a/sdk/src/events/parsing.rs
+++ b/sdk/src/events/parsing.rs
@@ -1,0 +1,531 @@
+//! This module defines transformers from various Sui types to Nexus event types.
+//! Namely we support:
+//! - Parsing GRPC [`sui_sdk_types::Event`]
+//! - Parsing GQL response type
+
+use {
+    crate::{
+        events::{
+            events_query::events_query::EventsQueryEventsNodesContents,
+            parse_bcs,
+            NexusEvent,
+        },
+        idents::primitives,
+        sui,
+        types::NexusObjects,
+    },
+    anyhow::bail,
+    serde_json::json,
+};
+
+/// [`sui_sdk_types::Event`] -> [`NexusEvent`]
+pub trait FromSuiGrpcEvent {
+    /// Parse a Sui GRPC event into a Nexus event.
+    fn from_sui_grpc_event(
+        index: u64,
+        digest: sui::types::Digest,
+        event: &sui::types::Event,
+        objects: &NexusObjects,
+    ) -> anyhow::Result<NexusEvent>;
+}
+
+/// [`EventsQueryEventsNodes`] -> [`NexusEvent`]
+pub trait FromSuiGqlEvent {
+    /// Parse a Sui GQL event into a Nexus event.
+    fn from_sui_gql_event(
+        index: u64,
+        digest: sui::types::Digest,
+        package_id: sui::types::Address,
+        event: &EventsQueryEventsNodesContents,
+        objects: &NexusObjects,
+    ) -> anyhow::Result<NexusEvent>;
+}
+
+impl FromSuiGrpcEvent for NexusEvent {
+    fn from_sui_grpc_event(
+        index: u64,
+        digest: sui::types::Digest,
+        event: &sui::types::Event,
+        objects: &NexusObjects,
+    ) -> anyhow::Result<NexusEvent> {
+        // Only accept events that come from the Nexus packages.
+        if !is_nexus_package(event.package_id, objects) {
+            bail!(
+                "Event does not come from a Nexus package, it comes from '{}' instead",
+                event.package_id
+            );
+        }
+
+        // Only accept events that are wrapped in `nexus_primitives::event::EventWrapper`.
+        if !is_event_wrapper(&event.type_, objects) {
+            bail!(
+                "Event is not wrapped in '{}::event::EventWrapper', found type: '{:?}'",
+                objects.primitives_pkg_id,
+                event.type_
+            );
+        }
+
+        // Extract the name of the event we want to parse into.
+        let Some(event_type) = event.type_.type_params().first().and_then(|tag| match tag {
+            sui::types::TypeTag::Struct(struct_tag) => Some(struct_tag),
+            _ => None,
+        }) else {
+            bail!("EventWrapper does not have a valid event type parameter");
+        };
+
+        let event_name = event_type.name().as_str();
+
+        Ok(NexusEvent {
+            id: (digest, index),
+            generics: event_type.type_params().to_vec(),
+            data: parse_bcs(event_name, &event.contents)?,
+        })
+    }
+}
+
+impl FromSuiGqlEvent for NexusEvent {
+    fn from_sui_gql_event(
+        index: u64,
+        digest: sui::types::Digest,
+        package_id: sui::types::Address,
+        event: &EventsQueryEventsNodesContents,
+        objects: &NexusObjects,
+    ) -> anyhow::Result<NexusEvent> {
+        // Only accept events that come from the Nexus packages.
+        if !is_nexus_package(package_id, objects) {
+            bail!("Event does not come from a Nexus package, it comes from '{package_id}' instead");
+        }
+
+        let struct_tag: sui::types::StructTag = event
+            .type_
+            .as_ref()
+            .and_then(|t| t.repr.parse().ok())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Failed to parse event type '{:?}' into StructTag",
+                    event.type_
+                )
+            })?;
+
+        // Only accept events that are wrapped in `nexus_primitives::event::EventWrapper`.
+        if !is_event_wrapper(&struct_tag, objects) {
+            bail!(
+                "Event is not wrapped in '{}::event::EventWrapper', found type: '{:?}'",
+                objects.primitives_pkg_id,
+                event.type_
+            );
+        }
+
+        // Extract the name of the event we want to parse into.
+        let Some(event_type) = struct_tag.type_params().first().and_then(|tag| match tag {
+            sui::types::TypeTag::Struct(struct_tag) => Some(struct_tag),
+            _ => None,
+        }) else {
+            bail!("EventWrapper does not have a valid event type parameter");
+        };
+
+        let event_name = event_type.name().as_str();
+
+        let Some(json) = event
+            .json
+            .as_ref()
+            .and_then(|j| j.as_object())
+            .and_then(|obj| obj.get("event"))
+        else {
+            bail!("Event contents missing JSON data");
+        };
+
+        let data = json!({
+            "_nexus_event_type": event_name,
+            "event": json
+        });
+
+        Ok(NexusEvent {
+            id: (digest, index),
+            generics: event_type.type_params().to_vec(),
+            data: serde_json::from_value(data)?,
+        })
+    }
+}
+
+/// Helper function to determine whether the given address is one of the Nexus
+/// package addresses.
+fn is_nexus_package(address: sui::types::Address, objects: &NexusObjects) -> bool {
+    address == objects.primitives_pkg_id
+        || address == objects.interface_pkg_id
+        || address == objects.workflow_pkg_id
+}
+
+/// Helper function to determine whether the provided struct tag corresponds to
+/// `nexus_primitives::event::EventWrapper`.
+fn is_event_wrapper(tag: &sui::types::StructTag, objects: &NexusObjects) -> bool {
+    *tag.address() == objects.primitives_pkg_id
+        && *tag.module() == primitives::Event::EVENT_WRAPPER.module
+        && *tag.name() == primitives::Event::EVENT_WRAPPER.name
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            events::{
+                events_query::events_query::EventsQueryEventsNodesContentsType,
+                DAGCreatedEvent,
+            },
+            idents::primitives,
+            test_utils::sui_mocks,
+        },
+        serde::{Deserialize, Serialize},
+    };
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct Wrapper<T> {
+        event: T,
+    }
+
+    #[test]
+    fn test_parse_from_grpc_valid_nexus_event() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let event_type = sui::types::StructTag::new(
+            objects.workflow_pkg_id,
+            sui::types::Identifier::new("dag").unwrap(),
+            sui::types::Identifier::new("DAGCreatedEvent").unwrap(),
+            vec![],
+        );
+
+        let wrapper_type = sui::types::TypeTag::Struct(Box::new(event_type.clone()));
+        // Manually craft a valid event kind and serialize as BCS
+        let dag_addr = sui::types::Address::generate(&mut rng);
+        let data = Wrapper {
+            event: DAGCreatedEvent { dag: dag_addr },
+        };
+        let bcs = bcs::to_bytes(&data).expect("BCS serialization should succeed");
+
+        let event = sui_mocks::mock_sui_event(
+            objects.primitives_pkg_id,
+            sui::types::StructTag::new(
+                objects.primitives_pkg_id,
+                primitives::Event::EVENT_WRAPPER.module,
+                primitives::Event::EVENT_WRAPPER.name,
+                vec![wrapper_type.clone()],
+            ),
+            bcs,
+        );
+
+        let result = NexusEvent::from_sui_grpc_event(index, digest, &event, &objects);
+        assert!(result.is_ok(), "Should parse valid Nexus event");
+        let nexus_event = result.unwrap();
+        assert_eq!(nexus_event.generics, vec![]);
+        assert_eq!(nexus_event.id, (digest, index));
+        assert!(matches!(
+            nexus_event.data,
+            crate::events::NexusEventKind::DAGCreated(DAGCreatedEvent { dag }) if dag == dag_addr
+        ));
+    }
+
+    #[test]
+    fn test_parse_from_grpc_non_nexus_package_event() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let event_type = sui::types::StructTag::new(
+            sui::types::Address::generate(&mut rng),
+            sui::types::Identifier::new("module").unwrap(),
+            sui::types::Identifier::new("EventName").unwrap(),
+            vec![],
+        );
+        let wrapper_type = sui::types::TypeTag::Struct(Box::new(event_type.clone()));
+
+        let event = sui_mocks::mock_sui_event(
+            sui::types::Address::generate(&mut rng),
+            sui::types::StructTag::new(
+                sui::types::Address::generate(&mut rng),
+                primitives::Event::EVENT_WRAPPER.module,
+                primitives::Event::EVENT_WRAPPER.name,
+                vec![wrapper_type],
+            ),
+            vec![1, 2, 3],
+        );
+
+        let result = NexusEvent::from_sui_grpc_event(index, digest, &event, &objects);
+        assert!(result.is_err(), "Should fail for non-Nexus package event");
+    }
+
+    #[test]
+    fn test_parse_from_grpc_non_event_wrapper_type() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let wrong_tag = sui::types::StructTag::new(
+            objects.primitives_pkg_id,
+            sui::types::Identifier::new("wrong_module").unwrap(),
+            sui::types::Identifier::new("wrong_name").unwrap(),
+            vec![],
+        );
+        let event = sui_mocks::mock_sui_event(objects.primitives_pkg_id, wrong_tag, vec![1, 2, 3]);
+        let result = NexusEvent::from_sui_grpc_event(index, digest, &event, &objects);
+        assert!(result.is_err(), "Should fail for non-EventWrapper type");
+    }
+
+    #[test]
+    fn test_parse_from_grpc_event_wrapper_missing_type_param() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let wrapper_tag = sui::types::StructTag::new(
+            objects.primitives_pkg_id,
+            sui::types::Identifier::new(primitives::Event::EVENT_WRAPPER.module.as_str()).unwrap(),
+            sui::types::Identifier::new(primitives::Event::EVENT_WRAPPER.name.as_str()).unwrap(),
+            vec![],
+        );
+        let event =
+            sui_mocks::mock_sui_event(objects.primitives_pkg_id, wrapper_tag, vec![1, 2, 3]);
+        let result = NexusEvent::from_sui_grpc_event(index, digest, &event, &objects);
+        assert!(result.is_err(), "Should fail for missing type param");
+    }
+
+    #[test]
+    fn test_parse_from_grpc_valid_nexus_event_with_generics() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let event_type = sui::types::StructTag::new(
+            objects.workflow_pkg_id,
+            sui::types::Identifier::new("dag").unwrap(),
+            sui::types::Identifier::new("DAGCreatedEvent").unwrap(),
+            vec![sui::types::TypeTag::U64],
+        );
+
+        let wrapper_type = sui::types::TypeTag::Struct(Box::new(event_type.clone()));
+        // Manually craft a valid event kind and serialize as BCS
+        let dag_addr = sui::types::Address::generate(&mut rng);
+        let data = Wrapper {
+            event: DAGCreatedEvent { dag: dag_addr },
+        };
+        let bcs = bcs::to_bytes(&data).expect("BCS serialization should succeed");
+
+        let event = sui_mocks::mock_sui_event(
+            objects.primitives_pkg_id,
+            sui::types::StructTag::new(
+                objects.primitives_pkg_id,
+                primitives::Event::EVENT_WRAPPER.module,
+                primitives::Event::EVENT_WRAPPER.name,
+                vec![wrapper_type.clone()],
+            ),
+            bcs,
+        );
+
+        let result = NexusEvent::from_sui_grpc_event(index, digest, &event, &objects);
+        assert!(result.is_ok(), "Should parse valid Nexus event");
+        let nexus_event = result.unwrap();
+        assert_eq!(nexus_event.id, (digest, index));
+        assert_eq!(nexus_event.generics, vec![sui::types::TypeTag::U64]);
+        assert!(matches!(
+            nexus_event.data,
+            crate::events::NexusEventKind::DAGCreated(DAGCreatedEvent { dag }) if dag == dag_addr
+        ));
+    }
+
+    #[test]
+    fn test_parse_from_gql_valid_nexus_event() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let primitives_pkg_id = objects.primitives_pkg_id;
+        let event_type = sui::types::StructTag::new(
+            objects.primitives_pkg_id,
+            sui::types::Identifier::new("dag").unwrap(),
+            sui::types::Identifier::new("DAGCreatedEvent").unwrap(),
+            vec![],
+        );
+        let wrapper_type = sui::types::TypeTag::Struct(Box::new(event_type.clone()));
+        let dag_addr = sui::types::Address::generate(&mut rng);
+        let data = Wrapper {
+            event: DAGCreatedEvent { dag: dag_addr },
+        };
+        let gql_event = EventsQueryEventsNodesContents {
+            json: Some(serde_json::to_value(&data).unwrap()),
+            type_: Some(EventsQueryEventsNodesContentsType {
+                repr: sui::types::StructTag::new(
+                    primitives_pkg_id,
+                    primitives::Event::EVENT_WRAPPER.module,
+                    primitives::Event::EVENT_WRAPPER.name,
+                    vec![wrapper_type.clone()],
+                )
+                .to_string(),
+            }),
+        };
+
+        let result =
+            NexusEvent::from_sui_gql_event(index, digest, primitives_pkg_id, &gql_event, &objects);
+        assert!(result.is_ok(), "Should parse valid Nexus GQL event");
+        let nexus_event = result.unwrap();
+        assert_eq!(nexus_event.generics, vec![]);
+        assert_eq!(nexus_event.id, (digest, index));
+        assert!(matches!(
+            nexus_event.data,
+            crate::events::NexusEventKind::DAGCreated(DAGCreatedEvent { dag }) if dag == dag_addr
+        ));
+    }
+
+    #[test]
+    fn test_parse_from_gql_non_nexus_package_event() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let non_nexus_pkg_id = sui::types::Address::generate(&mut rng);
+        let event_type = sui::types::StructTag::new(
+            non_nexus_pkg_id,
+            sui::types::Identifier::new("dag").unwrap(),
+            sui::types::Identifier::new("DAGCreatedEvent").unwrap(),
+            vec![],
+        );
+        let wrapper_type = sui::types::TypeTag::Struct(Box::new(event_type.clone()));
+        let dag_addr = sui::types::Address::generate(&mut rng);
+        let data = Wrapper {
+            event: DAGCreatedEvent { dag: dag_addr },
+        };
+        let gql_event = EventsQueryEventsNodesContents {
+            json: Some(serde_json::to_value(&data).unwrap()),
+            type_: Some(EventsQueryEventsNodesContentsType {
+                repr: sui::types::StructTag::new(
+                    non_nexus_pkg_id,
+                    primitives::Event::EVENT_WRAPPER.module,
+                    primitives::Event::EVENT_WRAPPER.name,
+                    vec![wrapper_type.clone()],
+                )
+                .to_string(),
+            }),
+        };
+        let result =
+            NexusEvent::from_sui_gql_event(index, digest, non_nexus_pkg_id, &gql_event, &objects);
+        assert!(
+            result.is_err(),
+            "Should fail for non-Nexus package GQL event"
+        );
+    }
+
+    #[test]
+    fn test_parse_from_gql_non_event_wrapper_gql_type() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let primitives_pkg_id = objects.primitives_pkg_id;
+        let event_type = sui::types::StructTag::new(
+            primitives_pkg_id,
+            sui::types::Identifier::new("dag").unwrap(),
+            sui::types::Identifier::new("DAGCreatedEvent").unwrap(),
+            vec![],
+        );
+        let wrapper_type = sui::types::TypeTag::Struct(Box::new(event_type.clone()));
+        let dag_addr = sui::types::Address::generate(&mut rng);
+        let data = Wrapper {
+            event: DAGCreatedEvent { dag: dag_addr },
+        };
+        // Use a non-wrapper struct tag
+        let non_wrapper_tag = sui::types::StructTag::new(
+            primitives_pkg_id,
+            sui::types::Identifier::new("not_wrapper").unwrap(),
+            sui::types::Identifier::new("not_wrapper").unwrap(),
+            vec![wrapper_type.clone()],
+        );
+        let gql_event = EventsQueryEventsNodesContents {
+            json: Some(serde_json::to_value(&data).unwrap()),
+            type_: Some(EventsQueryEventsNodesContentsType {
+                repr: non_wrapper_tag.to_string(),
+            }),
+        };
+        let result =
+            NexusEvent::from_sui_gql_event(index, digest, primitives_pkg_id, &gql_event, &objects);
+        assert!(result.is_err(), "Should fail for non-EventWrapper GQL type");
+    }
+
+    #[test]
+    fn test_parse_from_gql_event_wrapper_missing_type_param() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let primitives_pkg_id = objects.primitives_pkg_id;
+        // Wrapper tag with no type params
+        let wrapper_tag = sui::types::StructTag::new(
+            primitives_pkg_id,
+            primitives::Event::EVENT_WRAPPER.module,
+            primitives::Event::EVENT_WRAPPER.name,
+            vec![],
+        );
+        let dag_addr = sui::types::Address::generate(&mut rng);
+        let data = Wrapper {
+            event: DAGCreatedEvent { dag: dag_addr },
+        };
+        let gql_event = EventsQueryEventsNodesContents {
+            json: Some(serde_json::to_value(&data).unwrap()),
+            type_: Some(EventsQueryEventsNodesContentsType {
+                repr: wrapper_tag.to_string(),
+            }),
+        };
+        let result =
+            NexusEvent::from_sui_gql_event(index, digest, primitives_pkg_id, &gql_event, &objects);
+        assert!(
+            result.is_err(),
+            "Should fail for missing type param in GQL event"
+        );
+    }
+
+    #[test]
+    fn test_parse_from_gql_valid_nexus_event_with_generics() {
+        let mut rng = rand::thread_rng();
+        let index = 0u64;
+        let digest = sui::types::Digest::generate(&mut rng);
+        let objects = sui_mocks::mock_nexus_objects();
+        let primitives_pkg_id = objects.primitives_pkg_id;
+        let event_type = sui::types::StructTag::new(
+            primitives_pkg_id,
+            sui::types::Identifier::new("dag").unwrap(),
+            sui::types::Identifier::new("DAGCreatedEvent").unwrap(),
+            vec![sui::types::TypeTag::U64],
+        );
+        let wrapper_type = sui::types::TypeTag::Struct(Box::new(event_type.clone()));
+        let dag_addr = sui::types::Address::generate(&mut rng);
+        let data = Wrapper {
+            event: DAGCreatedEvent { dag: dag_addr },
+        };
+        let gql_event = EventsQueryEventsNodesContents {
+            json: Some(serde_json::to_value(&data).unwrap()),
+            type_: Some(EventsQueryEventsNodesContentsType {
+                repr: sui::types::StructTag::new(
+                    primitives_pkg_id,
+                    primitives::Event::EVENT_WRAPPER.module,
+                    primitives::Event::EVENT_WRAPPER.name,
+                    vec![wrapper_type.clone()],
+                )
+                .to_string(),
+            }),
+        };
+
+        let result =
+            NexusEvent::from_sui_gql_event(index, digest, primitives_pkg_id, &gql_event, &objects);
+        assert!(
+            result.is_ok(),
+            "Should parse valid Nexus GQL event with generics"
+        );
+        let nexus_event = result.unwrap();
+        assert_eq!(nexus_event.generics, vec![sui::types::TypeTag::U64]);
+        assert_eq!(nexus_event.id, (digest, index));
+        assert!(matches!(
+            nexus_event.data,
+            crate::events::NexusEventKind::DAGCreated(DAGCreatedEvent { dag }) if dag == dag_addr
+        ));
+    }
+}

--- a/sdk/src/types/nexus_data.rs
+++ b/sdk/src/types/nexus_data.rs
@@ -376,8 +376,7 @@ impl Storable for WalrusStorage {
 
         if store_for_epochs > WALRUS_MAX_EPOCHS {
             return Err(anyhow::anyhow!(
-                "Walrus save for epochs exceeds maximum allowed ({})",
-                WALRUS_MAX_EPOCHS
+                "Walrus save for epochs exceeds maximum allowed ({WALRUS_MAX_EPOCHS})"
             ));
         }
 

--- a/sdk/src/types/nexus_data_parser.rs
+++ b/sdk/src/types/nexus_data_parser.rs
@@ -54,8 +54,8 @@ impl NexusDataAsStruct {
 /// Check if a string represents a large number (u128/u256 range).
 /// Handles both positive and negative integers.
 fn is_large_number(s: &str) -> bool {
-    if s.starts_with('-') {
-        s[1..].chars().all(|c| c.is_ascii_digit()) && s.len() > 21
+    if let Some(stripped) = s.strip_prefix('-') {
+        stripped.chars().all(|c| c.is_ascii_digit()) && s.len() > 21
     } else {
         s.chars().all(|c| c.is_ascii_digit()) && s.len() > 20
     }
@@ -64,8 +64,9 @@ fn is_large_number(s: &str) -> bool {
 /// Wrap large numbers as JSON strings to preserve precision for u128/u256.
 fn wrap_large_numbers_as_string(value: &str) -> String {
     let trimmed = value.trim();
+
     if is_large_number(trimmed) {
-        format!(r#""{}""#, trimmed)
+        format!(r#""{trimmed}""#)
     } else {
         trimmed.to_string()
     }

--- a/sdk/src/types/nexus_objects.rs
+++ b/sdk/src/types/nexus_objects.rs
@@ -13,39 +13,37 @@ use {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NexusObjects {
-    pub workflow_pkg_id: sui::ObjectID,
-    pub primitives_pkg_id: sui::ObjectID,
-    pub interface_pkg_id: sui::ObjectID,
-    pub network_id: sui::ObjectID,
-    pub tool_registry: sui::ObjectRef,
-    pub default_tap: sui::ObjectRef,
-    pub gas_service: sui::ObjectRef,
-    pub pre_key_vault: sui::ObjectRef,
+    pub workflow_pkg_id: sui::types::Address,
+    pub primitives_pkg_id: sui::types::Address,
+    pub interface_pkg_id: sui::types::Address,
+    pub network_id: sui::types::Address,
+    pub tool_registry: sui::types::ObjectReference,
+    pub default_tap: sui::types::ObjectReference,
+    pub gas_service: sui::types::ObjectReference,
+    pub pre_key_vault: sui::types::ObjectReference,
 }
 
 #[cfg(feature = "sui_idents")]
 impl NexusObjects {
     /// Returns true when the event payload originates from the configured workflow or interface package.
-    pub fn is_event_from_nexus(&self, event: &sui::Event) -> bool {
-        use sui::MoveTypeTag;
-
-        let Some(MoveTypeTag::Struct(inner_tag)) = event.type_.type_params.first() else {
+    pub fn is_event_from_nexus(&self, event: &sui::types::Event) -> bool {
+        let Some(sui::types::TypeTag::Struct(inner_tag)) = event.type_.type_params().first() else {
             return false;
         };
 
-        if inner_tag.address == *self.workflow_pkg_id {
+        if *inner_tag.address() == self.workflow_pkg_id {
             return true;
         }
 
-        if inner_tag.address == *self.interface_pkg_id
-            && inner_tag.module.as_str() == "v1"
-            && inner_tag.name.as_str() == "AnnounceInterfacePackageEvent"
+        if *inner_tag.address() == self.interface_pkg_id
+            && inner_tag.module().as_str() == "v1"
+            && inner_tag.name().as_str() == "AnnounceInterfacePackageEvent"
         {
-            let Some(MoveTypeTag::Struct(witness)) = inner_tag.type_params.first() else {
+            let Some(sui::types::TypeTag::Struct(witness)) = inner_tag.type_params().first() else {
                 return false;
             };
 
-            return witness.address == *self.workflow_pkg_id;
+            return *witness.address() == self.workflow_pkg_id;
         }
 
         false
@@ -85,103 +83,100 @@ impl NexusObjects {
 
 #[cfg(all(test, feature = "sui_idents"))]
 mod tests {
-    use {super::*, serde_json::json};
+    use super::*;
 
     fn sample_objects() -> NexusObjects {
+        let mut rng = rand::thread_rng();
+
         NexusObjects {
-            workflow_pkg_id: sui::ObjectID::random(),
-            primitives_pkg_id: sui::ObjectID::random(),
-            interface_pkg_id: sui::ObjectID::random(),
-            network_id: sui::ObjectID::random(),
-            tool_registry: (
-                sui::ObjectID::random(),
-                sui::SequenceNumber::from_u64(1),
-                sui::ObjectDigest::random(),
-            )
-                .into(),
-            default_tap: (
-                sui::ObjectID::random(),
-                sui::SequenceNumber::from_u64(1),
-                sui::ObjectDigest::random(),
-            )
-                .into(),
-            gas_service: (
-                sui::ObjectID::random(),
-                sui::SequenceNumber::from_u64(1),
-                sui::ObjectDigest::random(),
-            )
-                .into(),
-            pre_key_vault: (
-                sui::ObjectID::random(),
-                sui::SequenceNumber::from_u64(1),
-                sui::ObjectDigest::random(),
-            )
-                .into(),
+            workflow_pkg_id: sui::types::Address::generate(&mut rng),
+            primitives_pkg_id: sui::types::Address::generate(&mut rng),
+            interface_pkg_id: sui::types::Address::generate(&mut rng),
+            network_id: sui::types::Address::generate(&mut rng),
+            tool_registry: sui::types::ObjectReference::new(
+                sui::types::Address::generate(&mut rng),
+                1,
+                sui::types::Digest::generate(&mut rng),
+            ),
+            default_tap: sui::types::ObjectReference::new(
+                sui::types::Address::generate(&mut rng),
+                1,
+                sui::types::Digest::generate(&mut rng),
+            ),
+            gas_service: sui::types::ObjectReference::new(
+                sui::types::Address::generate(&mut rng),
+                1,
+                sui::types::Digest::generate(&mut rng),
+            ),
+            pre_key_vault: sui::types::ObjectReference::new(
+                sui::types::Address::generate(&mut rng),
+                1,
+                sui::types::Digest::generate(&mut rng),
+            ),
         }
     }
 
-    fn wrap_event(objects: &NexusObjects, inner: sui::MoveStructTag) -> sui::Event {
-        sui::Event {
-            id: sui::EventID {
-                tx_digest: sui::TransactionDigest::random(),
-                event_seq: 0,
-            },
+    fn wrap_event(objects: &NexusObjects, inner: sui::types::StructTag) -> sui::types::Event {
+        let rng = &mut rand::thread_rng();
+
+        sui::types::Event {
             package_id: objects.primitives_pkg_id,
-            transaction_module: primitives::Event::EVENT_WRAPPER.module.into(),
-            sender: sui::Address::default(),
-            type_: sui::MoveStructTag {
-                address: *objects.primitives_pkg_id,
-                module: primitives::Event::EVENT_WRAPPER.module.into(),
-                name: primitives::Event::EVENT_WRAPPER.name.into(),
-                type_params: vec![sui::MoveTypeTag::Struct(Box::new(inner))],
-            },
-            parsed_json: json!({}),
-            bcs: sui::BcsEvent::Base64 { bcs: vec![] },
-            timestamp_ms: None,
+            module: primitives::Event::EVENT_WRAPPER.module,
+            sender: sui::types::Address::generate(rng),
+            type_: sui::types::StructTag::new(
+                objects.primitives_pkg_id,
+                primitives::Event::EVENT_WRAPPER.module,
+                primitives::Event::EVENT_WRAPPER.name,
+                vec![sui::types::TypeTag::Struct(Box::new(inner))],
+            ),
+            contents: vec![],
         }
     }
 
     #[test]
     fn matches_workflow_and_interface_events() {
         let objects = sample_objects();
+        let rng = &mut rand::thread_rng();
 
         let workflow_event = wrap_event(
             &objects,
-            sui::MoveStructTag {
-                address: *objects.workflow_pkg_id,
-                module: workflow::Scheduler::TASK.module.into(),
-                name: workflow::Scheduler::TASK.name.into(),
-                type_params: vec![],
-            },
+            sui::types::StructTag::new(
+                objects.workflow_pkg_id,
+                workflow::Scheduler::TASK.module,
+                workflow::Scheduler::TASK.name,
+                vec![],
+            ),
         );
 
         assert!(objects.is_event_from_nexus(&workflow_event));
 
         let interface_event = wrap_event(
             &objects,
-            sui::MoveStructTag {
-                address: *objects.interface_pkg_id,
-                module: sui::move_ident_str!("v1").into(),
-                name: sui::move_ident_str!("AnnounceInterfacePackageEvent").into(),
-                type_params: vec![sui::MoveTypeTag::Struct(Box::new(sui::MoveStructTag {
-                    address: *objects.workflow_pkg_id,
-                    module: workflow::Scheduler::TASK.module.into(),
-                    name: workflow::Scheduler::TASK.name.into(),
-                    type_params: vec![],
-                }))],
-            },
+            sui::types::StructTag::new(
+                objects.interface_pkg_id,
+                sui::types::Identifier::from_static("v1"),
+                sui::types::Identifier::from_static("AnnounceInterfacePackageEvent"),
+                vec![sui::types::TypeTag::Struct(Box::new(
+                    sui::types::StructTag::new(
+                        objects.workflow_pkg_id,
+                        workflow::Scheduler::TASK.module,
+                        workflow::Scheduler::TASK.name,
+                        vec![],
+                    ),
+                ))],
+            ),
         );
 
         assert!(objects.is_event_from_nexus(&interface_event));
 
         let unrelated_event = wrap_event(
             &objects,
-            sui::MoveStructTag {
-                address: sui::ObjectID::random().into(),
-                module: sui::move_ident_str!("foo").into(),
-                name: sui::move_ident_str!("bar").into(),
-                type_params: vec![],
-            },
+            sui::types::StructTag::new(
+                sui::types::Address::generate(rng),
+                sui::types::Identifier::from_static("foo"),
+                sui::types::Identifier::from_static("bar"),
+                vec![],
+            ),
         );
 
         assert!(!objects.is_event_from_nexus(&unrelated_event));

--- a/sdk/src/types/scheduler.rs
+++ b/sdk/src/types/scheduler.rs
@@ -2,12 +2,7 @@
 //! It provides a way to serialize and deserialize the task and any helper structures.
 use {
     super::{
-        serde_parsers::{
-            deserialize_sui_address,
-            deserialize_sui_u64,
-            serialize_sui_address,
-            serialize_sui_u64,
-        },
+        serde_parsers::{deserialize_sui_u64, serialize_sui_u64},
         TypeName,
     },
     crate::sui,
@@ -16,11 +11,14 @@ use {
     std::borrow::Cow,
 };
 
+// TODO: @david - these types can be simplified with the new object crawler grpc
+// implementation. Probably can drop the custom deserialization logic.
+
 /// Representation of `nexus_workflow::dag::DagExecutionConfig`.
 #[derive(Clone, Debug, Serialize)]
 pub struct DagExecutionConfig {
-    pub dag: sui::ObjectID,
-    pub network: sui::ObjectID,
+    pub dag: sui::types::Address,
+    pub network: sui::types::Address,
     #[serde(
         deserialize_with = "deserialize_sui_u64",
         serialize_with = "serialize_sui_u64"
@@ -30,22 +28,14 @@ pub struct DagExecutionConfig {
     pub entry_group: Value,
     #[serde(default)]
     pub inputs: Value,
-    #[serde(
-        deserialize_with = "deserialize_sui_address",
-        serialize_with = "serialize_sui_address"
-    )]
-    pub invoker: sui::Address,
+    pub invoker: sui::types::Address,
 }
 
 /// Representation of `nexus_workflow::scheduler::Task`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Task {
-    pub id: sui::UID,
-    #[serde(
-        deserialize_with = "deserialize_sui_address",
-        serialize_with = "serialize_sui_address"
-    )]
-    pub owner: sui::Address,
+    pub id: sui::types::Address,
+    pub owner: sui::types::Address,
     #[serde(default)]
     pub metadata: Value,
     #[serde(default)]
@@ -60,7 +50,7 @@ pub struct Task {
 /// Minimal representation of `nexus_primitives::policy::Policy`.
 #[derive(Clone, Debug, Serialize)]
 pub struct Policy {
-    pub id: sui::UID,
+    pub id: sui::types::Address,
     pub dfa: ConfiguredAutomaton,
     #[serde(default)]
     pub alphabet_index: Value,
@@ -76,7 +66,7 @@ pub struct Policy {
 /// Minimal representation of `nexus_primitives::automaton::ConfiguredAutomaton`.
 #[derive(Clone, Debug, Serialize)]
 pub struct ConfiguredAutomaton {
-    pub id: sui::UID,
+    pub id: sui::types::Address,
     #[serde(default)]
     pub dfa: Value,
 }
@@ -85,7 +75,7 @@ pub struct ConfiguredAutomaton {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum PolicySymbol {
     Witness(MoveTypeName),
-    Uid(sui::ObjectID),
+    Uid(sui::types::Address),
 }
 
 impl Serialize for PolicySymbol {
@@ -126,7 +116,7 @@ impl<'de> Deserialize<'de> for PolicySymbol {
             #[serde(default)]
             witness: Option<MoveTypeName>,
             #[serde(default)]
-            uid: Option<sui::ObjectID>,
+            uid: Option<sui::types::Address>,
         }
 
         #[derive(Deserialize)]
@@ -172,7 +162,7 @@ impl PolicySymbol {
         }
     }
 
-    pub fn as_uid(&self) -> Option<&sui::ObjectID> {
+    pub fn as_uid(&self) -> Option<&sui::types::Address> {
         match self {
             PolicySymbol::Uid(uid) => Some(uid),
             PolicySymbol::Witness(_) => None,
@@ -274,7 +264,7 @@ impl<'de> Deserialize<'de> for Policy {
     {
         #[derive(Deserialize)]
         struct Inner {
-            id: sui::UID,
+            id: sui::types::Address,
             dfa: ConfiguredAutomaton,
             #[serde(default)]
             alphabet_index: Value,
@@ -306,7 +296,7 @@ impl<'de> Deserialize<'de> for ConfiguredAutomaton {
     {
         #[derive(Deserialize)]
         struct Inner {
-            id: sui::UID,
+            id: sui::types::Address,
             #[serde(default)]
             dfa: Value,
         }
@@ -327,8 +317,8 @@ impl<'de> Deserialize<'de> for DagExecutionConfig {
     {
         #[derive(Deserialize)]
         struct Inner {
-            dag: sui::ObjectID,
-            network: sui::ObjectID,
+            dag: sui::types::Address,
+            network: sui::types::Address,
             #[serde(
                 deserialize_with = "deserialize_sui_u64",
                 serialize_with = "serialize_sui_u64"
@@ -338,11 +328,7 @@ impl<'de> Deserialize<'de> for DagExecutionConfig {
             entry_group: Value,
             #[serde(default)]
             inputs: Value,
-            #[serde(
-                deserialize_with = "deserialize_sui_address",
-                serialize_with = "serialize_sui_address"
-            )]
-            invoker: sui::Address,
+            invoker: sui::types::Address,
         }
 
         let inner: Inner = deserialize_move_struct(deserializer)?;
@@ -464,28 +450,24 @@ fn is_value_wrapper_key(key: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        serde_json::json,
-        sui::{move_ident_str, MoveStructTag, MoveTypeTag, ObjectID},
-    };
+    use {super::*, crate::idents::sui_framework, serde_json::json};
 
     #[test]
     fn policy_deserializes_from_wrapped_move_struct() {
-        let policy_id = ObjectID::from_hex_literal("0x2").expect("valid object id");
-        let dfa_id = ObjectID::from_hex_literal("0x3").expect("valid object id");
+        let policy_id = sui::types::Address::from_static("0x2");
+        let dfa_id = sui::types::Address::from_static("0x3");
 
         let expected = Policy {
-            id: sui::UID::new(policy_id),
+            id: policy_id,
             dfa: ConfiguredAutomaton {
-                id: sui::UID::new(dfa_id),
+                id: dfa_id,
                 dfa: json!({
-                    "type": MoveStructTag {
-                        address: *sui::FRAMEWORK_PACKAGE_ID,
-                        module: move_ident_str!("dummy").into(),
-                        name: move_ident_str!("Config").into(),
-                        type_params: vec![MoveTypeTag::Address],
-                    }
+                    "type": sui::types::StructTag::new(
+                        sui_framework::PACKAGE_ID,
+                        sui::types::Identifier::from_static("dummy"),
+                        sui::types::Identifier::from_static("Config"),
+                        vec![sui::types::TypeTag::Address],
+                    ),
                 }),
             },
             alphabet_index: Value::Null,
@@ -507,9 +489,10 @@ mod tests {
 
     #[test]
     fn dag_execution_config_deserializes_from_wrapped_move_struct() {
-        let dag_id = ObjectID::from_hex_literal("0xabc").expect("valid object id");
-        let network_id = ObjectID::from_hex_literal("0xdef").expect("valid object id");
-        let invoker = sui::Address::random_for_testing_only();
+        let mut rng = rand::thread_rng();
+        let dag_id = sui::types::Address::generate(&mut rng);
+        let network_id = sui::types::Address::generate(&mut rng);
+        let invoker = sui::types::Address::generate(&mut rng);
 
         let expected = DagExecutionConfig {
             dag: dag_id,

--- a/sdk/src/types/serde_parsers.rs
+++ b/sdk/src/types/serde_parsers.rs
@@ -1,5 +1,4 @@
 use {
-    crate::sui,
     serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize},
     serde_json::Value,
 };
@@ -124,25 +123,6 @@ where
         Some(inner) => Value::String(inner.to_string()).serialize(serializer),
         None => serializer.serialize_none(),
     }
-}
-
-/// Deserialize a Sui address represented as a string.
-pub fn deserialize_sui_address<'de, D>(deserializer: D) -> Result<sui::Address, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value: String = Deserialize::deserialize(deserializer)?;
-    value
-        .parse::<sui::Address>()
-        .map_err(serde::de::Error::custom)
-}
-
-/// Serialize a Sui address as a hex string.
-pub fn serialize_sui_address<S>(value: &sui::Address, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&value.to_string())
 }
 
 /// Deserialize a `Vec<u8>` into a `String` using lossy UTF-8 conversion.

--- a/sdk/src/types/storage_kind.rs
+++ b/sdk/src/types/storage_kind.rs
@@ -20,7 +20,7 @@ impl FromStr for StorageKind {
         match s.to_lowercase().as_str() {
             "inline" => Ok(StorageKind::Inline),
             "walrus" => Ok(StorageKind::Walrus),
-            _ => Err(format!("Invalid storage kind: {}", s)),
+            _ => Err(format!("Invalid storage kind: {s}")),
         }
     }
 }

--- a/sdk/src/types/tool_meta.rs
+++ b/sdk/src/types/tool_meta.rs
@@ -7,7 +7,7 @@ use {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ToolMeta {
     pub fqn: ToolFqn,
-    pub url: reqwest::Url,
+    pub url: String,
     pub description: String,
     pub input_schema: serde_json::Value,
     pub output_schema: serde_json::Value,


### PR DESCRIPTION
## Notable changes

- change SDK `types` module to use new `sui-rust-sdk` types
- change Nexus events definitions to use new types and parse from GRPC and GQL

## References

- references https://github.com/Talus-Network/nexus/issues/594

## Checklist

- ~~[ ] keep a changelog~~
- [x] write tests
- [x] create tickets for `TODO: <>` statements
- ~~[ ] create or update documentation~~
