### PR TITLE
fix: event polling error handling and handshake PTB

### DIFF
--- a/sdk/src/events/parsing.rs
+++ b/sdk/src/events/parsing.rs
@@ -766,7 +766,8 @@ mod tests {
         let page = receiver
             .recv()
             .await
-            .expect("fetcher should yield a page of events");
+            .expect("fetcher should yield a page of events")
+            .expect("result should be Ok");
 
         assert_eq!(page.events.len(), events.len());
 

--- a/sdk/src/nexus/crypto.rs
+++ b/sdk/src/nexus/crypto.rs
@@ -143,7 +143,10 @@ impl CryptoActions {
             tokio::select! {
                 result = next_page.recv() => {
                     let page = match result {
-                        Some(page) => page,
+                        Some(Ok(page)) => page,
+                        Some(Err(e)) => {
+                            return Err(NexusError::Channel(anyhow!("Error fetching events: {}", e)));
+                        }
                         None => {
                             return Err(NexusError::Channel(anyhow!("Event fetcher stopped unexpectedly")));
                         }

--- a/sdk/src/nexus/workflow.rs
+++ b/sdk/src/nexus/workflow.rs
@@ -275,7 +275,8 @@ impl WorkflowActions {
                     tokio::select! {
                         maybe_page = next_page.recv() => {
                             let events = match maybe_page {
-                                Some(EventPage { events, .. }) => events,
+                                Some(Ok(EventPage { events, .. })) => events,
+                                Some(Err(e)) => return Err(NexusError::Channel(anyhow!("Error fetching events: {}", e))),
                                 None => return Err(NexusError::Channel(anyhow!("Event stream closed unexpectedly while inspecting DAG execution '{dag_execution_id}'"))),
                             };
 

--- a/sdk/src/transactions/crypto.rs
+++ b/sdk/src/transactions/crypto.rs
@@ -113,10 +113,10 @@ pub fn claim_and_fulfill_pre_key_for_user(
     let requested_by_arg = sui_framework::Address::address_from_type(tx, requested_by)?;
 
     // `leader_cap: &CloneableOwnerCap<OverNetwork>`
-    let leader_cap_obj = tx.input(sui::tx::Input::owned(
+    let leader_cap_obj = tx.input(sui::tx::Input::shared(
         *leader_cap.object_id(),
         leader_cap.version(),
-        *leader_cap.digest(),
+        false,
     ));
 
     // Claim gas from the requester into a temporary balance.


### PR DESCRIPTION
## Notable changes

- improved event polling interface to send errors over the channel

## References

- references https://github.com/Talus-Network/nexus/issues/627

## Checklist

- ~~[ ] keep a changelog~~
- [x] write tests
- ~~[ ] create tickets for `TODO: <>` statements~~
- ~~[ ] create or update documentation~~
