### PR TITLE
[0.5.0] fix: Add back object mutability field

### DIFF
--- a/sdk/src/onchain_schema_gen/mod.rs
+++ b/sdk/src/onchain_schema_gen/mod.rs
@@ -10,5 +10,5 @@ mod types;
 pub use {
     input::generate_input_schema,
     output::generate_output_schema,
-    types::{convert_move_type_to_schema, is_tx_context_param},
+    types::{convert_move_signature_to_schema, convert_move_type_to_schema, is_tx_context_param},
 };


### PR DESCRIPTION
## Notable changes

- Adds back mutability field for onchain tool input schema arguments since it _is_ available. The reference info can be found in `sui::grpc::OpenSignature` instead of `sui::grpc::OpenSignatureBody`

## References

- provide a list of tickets this PR resolves or references

## Checklist

- [ ] keep a changelog
- [x] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
