### PR TITLE
fix(cli): initialize the global logger

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,7 +83,7 @@ async fn main() {
 
     env_logger::builder()
         .filter(None, cli.verbose.log_level_filter())
-        .build();
+        .init();
 
     JSON_MODE.store(cli.json, Ordering::Relaxed);
 


### PR DESCRIPTION

## Notable changes

- fixes the `--verbose` flag by initializing the global logger instead of
building a local logger.

## References

- #362
