### PR TITLE
Add precise event type filtering to `poll_nexus_events`

### DIFF
--- a/sdk/src/events/parsing.rs
+++ b/sdk/src/events/parsing.rs
@@ -762,7 +762,7 @@ mod tests {
             objects.clone(),
         );
 
-        let (_poller, mut receiver) = fetcher.poll_nexus_events(None, None);
+        let (_poller, mut receiver) = fetcher.poll_nexus_events(None, None, None);
         let page = receiver
             .recv()
             .await

--- a/sdk/src/nexus/crypto.rs
+++ b/sdk/src/nexus/crypto.rs
@@ -138,7 +138,7 @@ impl CryptoActions {
         let fetcher = self.client.event_fetcher();
         let timeout = tokio::time::sleep(Duration::from_secs(20));
 
-        let (_poller, mut next_page) = fetcher.poll_nexus_events(None, Some(checkpoint));
+        let (_poller, mut next_page) = fetcher.poll_nexus_events(None, Some(checkpoint), None);
 
         tokio::pin!(timeout);
 

--- a/sdk/src/nexus/workflow.rs
+++ b/sdk/src/nexus/workflow.rs
@@ -270,7 +270,7 @@ impl WorkflowActions {
 
             tokio::spawn(async move {
                 let (_poller, mut next_page) =
-                    fetcher.poll_nexus_events(None, Some(execution_checkpoint));
+                    fetcher.poll_nexus_events(None, Some(execution_checkpoint), None);
 
                 let timeout = tokio::time::sleep(timeout);
 


### PR DESCRIPTION
## Add precise event type filtering to `poll_nexus_events`

### Summary

- Added optional `inner_type` parameter to `EventFetcher::poll_nexus_events()` for precise type filtering
- When `Some(type_tag)` is passed, constructs `EventWrapper<type_tag>` instead of `EventWrapper<*>` for the existing GraphQL type filter
- Backward compatible: passing `None` maintains existing behavior (fetches all events)

### Motivation

In test scenarios where multiple deployments share the same `primitives_pkg_id` but have different `workflow_pkg_id` values, fetching all `EventWrapper<*>` events and filtering client-side creates empty pages when events from other `workflow_pkg_id` instances are dropped. This caused flaky tests in `nexus-next`.

By specifying the full inner type (e.g., `EventWrapper<workflow_pkg_id::leader_cap::FoundingLeaderCapCreatedEvent>`), the existing GraphQL type filter returns only matching events, eliminating cross-deployment pollution at the source.

### Changes

- `fetching.rs`: Added `inner_type: Option<sui::types::TypeTag>` parameter that populates the `StructTag` type params
- Updated all call sites to pass `None` for backward compatibility

### Test plan

- [x] Existing SDK tests pass
- [x] Tested in nexus-next capability bootstrap scenario
