### PR TITLE
feat: simplify offchain tool registration CLI + built-in --meta flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### `nexus-cli`
+
+#### Added
+
+- `nexus tool register offchain --from-meta <FILE|->` to register tools from a JSON metadata file or stdin, bypassing the live HTTP endpoint
+- `nexus tool auth list-keys --tool-fqn <FQN>` to query registered message-signing keys for a tool
+- `nexus tool auth register-key --skip-if-active` for idempotent key registration in CI pipelines
+
+### `nexus-sdk`
+
+#### Added
+
+- `ToolKeyEntry` and `ToolKeyList` types in `nexus::network_auth`
+- `list_tool_keys()` method on `NetworkAuthActions`
+
+### `nexus-toolkit`
+
+#### Added
+
+- Built-in `--meta` flag in the `bootstrap!` macro: prints a JSON array of tool metadata to stdout and exits without starting the HTTP server
+
 ## [`0.8.2`] - 2026-03-30
 
 ### `nexus-cli`

--- a/cli/src/tool/mod.rs
+++ b/cli/src/tool/mod.rs
@@ -68,8 +68,25 @@ pub(crate) enum ToolAuthCommand {
         )]
         description: Option<String>,
 
+        #[arg(
+            long = "skip-if-active",
+            help = "Skip registration if the same public key is already the active key (idempotent). Useful in CI to avoid re-registering an unchanged key."
+        )]
+        skip_if_active: bool,
+
         #[command(flatten)]
         gas: GasArgs,
+    },
+
+    #[command(about = "List all registered message-signing keys for a tool.")]
+    ListKeys {
+        #[arg(
+            long = "tool-fqn",
+            short = 't',
+            help = "The fully qualified name (FQN) of the tool.",
+            value_name = "FQN"
+        )]
+        tool_fqn: ToolFqn,
     },
 
     #[command(
@@ -128,8 +145,21 @@ pub(crate) enum ToolAuthCommand {
 pub(crate) enum RegisterCommand {
     #[command(about = "Register an offchain tool")]
     Offchain {
-        #[arg(long = "url", short = 'u', help = "The URL of the offchain tool")]
-        url: reqwest::Url,
+        #[arg(
+            long = "url",
+            short = 'u',
+            help = "The URL of the offchain tool. Required unless --from-meta is provided.",
+            required_unless_present = "from_meta"
+        )]
+        url: Option<reqwest::Url>,
+
+        #[arg(
+            long = "from-meta",
+            help = "Path to a JSON file containing tool metadata (as produced by the tool binary's --meta flag), or '-' to read from stdin. Skips the live HTTP validation step.",
+            value_name = "FILE|-",
+            conflicts_with = "batch"
+        )]
+        from_meta: Option<String>,
 
         #[arg(
             long = "collateral-coin",
@@ -150,7 +180,7 @@ pub(crate) enum RegisterCommand {
 
         #[arg(
             long = "batch",
-            help = "Should all tools on a webserver be registered at once?"
+            help = "Should all tools on a webserver be registered at once? Incompatible with --from-meta."
         )]
         batch: bool,
 
@@ -425,6 +455,7 @@ pub(crate) async fn handle(command: ToolCommand) -> AnyResult<(), NexusCliError>
         ToolCommand::Register { tool_type } => match tool_type {
             RegisterCommand::Offchain {
                 url,
+                from_meta,
                 collateral_coin,
                 invocation_cost,
                 batch,
@@ -433,6 +464,7 @@ pub(crate) async fn handle(command: ToolCommand) -> AnyResult<(), NexusCliError>
             } => {
                 register_off_chain_tool(
                     url,
+                    from_meta,
                     collateral_coin,
                     invocation_cost,
                     batch,

--- a/cli/src/tool/tool_auth.rs
+++ b/cli/src/tool/tool_auth.rs
@@ -28,8 +28,20 @@ pub(crate) async fn handle_tool_auth(cmd: ToolAuthCommand) -> AnyResult<(), Nexu
             owner_cap,
             signing_key,
             description,
+            skip_if_active,
             gas,
-        } => register_key(tool_fqn, owner_cap, signing_key, description, gas).await,
+        } => {
+            register_key(
+                tool_fqn,
+                owner_cap,
+                signing_key,
+                description,
+                skip_if_active,
+                gas,
+            )
+            .await
+        }
+        ToolAuthCommand::ListKeys { tool_fqn } => list_keys(tool_fqn).await,
         ToolAuthCommand::ExportAllowedLeaders { all, leaders, out } => {
             export_allowed_leaders(all, leaders, out).await
         }
@@ -69,6 +81,7 @@ async fn register_key(
     owner_cap: Option<sui::types::Address>,
     signing_key: String,
     description: Option<String>,
+    skip_if_active: bool,
     gas: GasArgs,
 ) -> AnyResult<(), NexusCliError> {
     command_title!("Registering signed HTTP key for tool '{tool_fqn}'");
@@ -102,6 +115,59 @@ async fn register_key(
     key_handle.success();
 
     let nexus_client = get_nexus_client(gas.sui_gas_coin, gas.sui_gas_budget).await?;
+
+    // When --skip-if-active is requested, check whether the same public key is
+    // already the active key. If it is, skip the on-chain transaction entirely
+    // so the command is safe to run repeatedly in CI without accumulating
+    // duplicate key registrations.
+    //
+    // Note: this check is best-effort. There is a TOCTOU (Time-Of-Check to
+    // Time-Of-Use) gap between this read and the subsequent registration call.
+    // Concurrent invocations may both see "key not active" and both proceed,
+    // resulting in the same public key registered twice with different key IDs.
+    // This is non-fatal (no on-chain corruption, just an extra key entry) and
+    // acceptable for a CI convenience flag targeting single-pipeline usage.
+    if skip_if_active {
+        let new_pubkey_hex = hex::encode(signing_key.verifying_key().to_bytes());
+
+        let check_handle = loading!("Checking current active key...");
+
+        match nexus_client
+            .network_auth()
+            .list_tool_keys(&tool_fqn)
+            .await
+            .map_err(NexusCliError::Nexus)?
+        {
+            Some(list) => {
+                if let Some(active_kid) = list.active_key_id {
+                    if let Some(active) = list.keys.iter().find(|k| k.kid == active_kid) {
+                        if active.public_key_hex == new_pubkey_hex {
+                            check_handle.success();
+
+                            notify_success!(
+                                "Key is already the active key (kid={kid}), skipping registration.",
+                                kid = active_kid
+                            );
+
+                            return json_output(&json!({
+                                "tool_fqn": tool_fqn,
+                                "skipped": true,
+                                "reason": "key already active",
+                                "active_kid": active_kid,
+                                "public_key_hex": new_pubkey_hex,
+                            }));
+                        }
+                    }
+                }
+
+                check_handle.success();
+            }
+            None => {
+                // No binding yet — proceed with first-time registration.
+                check_handle.success();
+            }
+        }
+    }
     let description_bytes = description.map(|s| s.into_bytes());
 
     let handle = loading!("Submitting network_auth transaction...");
@@ -119,6 +185,53 @@ async fn register_key(
         "tool_kid": result.tool_kid,
         "public_key_hex": hex::encode(result.public_key),
     }))?;
+
+    Ok(())
+}
+
+/// Query and display all registered message-signing keys for the given tool FQN.
+async fn list_keys(tool_fqn: ToolFqn) -> AnyResult<(), NexusCliError> {
+    command_title!("Listing keys for tool '{tool_fqn}'");
+
+    let nexus_client = get_nexus_client(None, DEFAULT_GAS_BUDGET).await?;
+
+    let handle = loading!("Fetching key binding...");
+    let list = match nexus_client.network_auth().list_tool_keys(&tool_fqn).await {
+        Ok(list) => {
+            handle.success();
+            list
+        }
+        Err(e) => {
+            handle.error();
+            return Err(NexusCliError::Nexus(e));
+        }
+    };
+
+    match list {
+        None => {
+            json_output(&json!({
+                "tool_fqn": tool_fqn,
+                "binding_object_id": null,
+                "active_key_id": null,
+                "next_key_id": null,
+                "keys": [],
+            }))?;
+        }
+        Some(list) => {
+            json_output(&json!({
+                "tool_fqn": tool_fqn,
+                "binding_object_id": list.binding_object_id,
+                "active_key_id": list.active_key_id,
+                "next_key_id": list.next_key_id,
+                "keys": list.keys.iter().map(|k| json!({
+                    "kid": k.kid,
+                    "public_key_hex": k.public_key_hex,
+                    "added_at_ms": k.added_at_ms,
+                    "revoked": k.revoked,
+                })).collect::<Vec<_>>(),
+            }))?;
+        }
+    }
 
     Ok(())
 }
@@ -244,6 +357,9 @@ async fn sync_allowed_leaders(
 mod tests {
     use {super::*, clap::Parser};
 
+    /// Verifies that clap correctly parses the humantime duration format for
+    /// `sync-allowed-leaders --interval`. Guards against regressions where the
+    /// custom value_parser is accidentally removed or replaced.
     #[test]
     fn clap_parses_sync_allowed_leaders_interval() {
         let cli = crate::Cli::try_parse_from([
@@ -276,6 +392,8 @@ mod tests {
         }
     }
 
+    /// Verifies that clap rejects non-duration strings for `--interval`.
+    /// Guards against the custom value_parser being silently bypassed.
     #[test]
     fn clap_rejects_invalid_sync_allowed_leaders_interval() {
         assert!(crate::Cli::try_parse_from([
@@ -292,6 +410,8 @@ mod tests {
         .is_err());
     }
 
+    /// Verifies that a zero-length interval is rejected at runtime (not just at parse time).
+    /// Guards against the `interval.is_zero()` guard being removed.
     #[tokio::test]
     async fn sync_allowed_leaders_rejects_zero_interval() {
         let out_dir = tempfile::tempdir().unwrap();
@@ -301,5 +421,45 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("invalid duration"));
+    }
+
+    /// Verifies that `register-key --skip-if-active` is accepted by clap.
+    /// Guards against the flag being accidentally dropped from the command definition.
+    #[test]
+    fn clap_parses_register_key_skip_if_active_flag() {
+        assert!(crate::Cli::try_parse_from([
+            "nexus",
+            "tool",
+            "auth",
+            "register-key",
+            "--tool-fqn",
+            "xyz.demo.tool@1",
+            "--signing-key",
+            "deadbeef",
+            "--skip-if-active",
+        ])
+        .is_ok());
+    }
+
+    /// Verifies that `list-keys` is accepted by clap with a valid FQN.
+    /// Guards against the subcommand being accidentally removed.
+    #[test]
+    fn clap_parses_list_keys() {
+        let cli = crate::Cli::try_parse_from([
+            "nexus",
+            "tool",
+            "auth",
+            "list-keys",
+            "--tool-fqn",
+            "xyz.demo.tool@1",
+        ])
+        .unwrap();
+
+        match cli.command {
+            crate::Command::Tool(crate::tool::ToolCommand::Auth { cmd }) => {
+                assert!(matches!(cmd, ToolAuthCommand::ListKeys { .. }));
+            }
+            _ => panic!("unexpected command"),
+        }
     }
 }

--- a/cli/src/tool/tool_register_offchain.rs
+++ b/cli/src/tool/tool_register_offchain.rs
@@ -383,7 +383,7 @@ pub(crate) async fn register_off_chain_tool(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, clap::Parser};
 
     /// Helper: returns a valid `ToolMeta` JSON string with the given URL.
     fn valid_meta_json(url: &str) -> String {
@@ -513,5 +513,62 @@ mod tests {
             err.to_string().contains("failed to read meta file"),
             "got: {err}"
         );
+    }
+
+    // -- Clap constraint tests --
+
+    /// Verifies that `--url` is not required when `--from-meta` is provided.
+    /// Guards against the `required_unless_present` constraint being removed.
+    #[test]
+    fn clap_accepts_from_meta_without_url() {
+        assert!(crate::Cli::try_parse_from([
+            "nexus",
+            "tool",
+            "register",
+            "offchain",
+            "--from-meta",
+            "meta.json",
+        ])
+        .is_ok());
+    }
+
+    /// Verifies that `--url` is required when `--from-meta` is absent.
+    /// Guards against `required_unless_present` being accidentally removed.
+    #[test]
+    fn clap_rejects_offchain_without_url_or_from_meta() {
+        assert!(crate::Cli::try_parse_from(["nexus", "tool", "register", "offchain",]).is_err());
+    }
+
+    /// Verifies that `--from-meta` and `--batch` cannot be used together.
+    /// Guards against the `conflicts_with` constraint being removed.
+    #[test]
+    fn clap_rejects_from_meta_with_batch() {
+        assert!(crate::Cli::try_parse_from([
+            "nexus",
+            "tool",
+            "register",
+            "offchain",
+            "--from-meta",
+            "meta.json",
+            "--batch",
+        ])
+        .is_err());
+    }
+
+    /// Verifies that `--from-meta` and `--url` can be used together (URL override).
+    /// Guards against an accidental `conflicts_with` between the two.
+    #[test]
+    fn clap_accepts_from_meta_with_url_override() {
+        assert!(crate::Cli::try_parse_from([
+            "nexus",
+            "tool",
+            "register",
+            "offchain",
+            "--from-meta",
+            "meta.json",
+            "--url",
+            "https://override.example.com",
+        ])
+        .is_ok());
     }
 }

--- a/cli/src/tool/tool_register_offchain.rs
+++ b/cli/src/tool/tool_register_offchain.rs
@@ -11,14 +11,261 @@ use {
     },
     nexus_sdk::{
         idents::{primitives, workflow},
-        nexus::error::NexusError,
+        nexus::{client::NexusClient, error::NexusError},
         transactions::tool,
+        types::ToolMeta,
     },
+    std::io::Read as _,
 };
 
+/// Load `ToolMeta` from a file path or stdin (`-`), optionally overriding the `url` field.
+///
+/// This is used by `--from-meta` to bypass the live HTTP validation step. The
+/// `output_schema["oneOf"]` invariant is still checked here so that invalid
+/// meta is rejected before any on-chain transaction is attempted.
+fn load_meta_from_source(
+    source: &str,
+    url_override: Option<reqwest::Url>,
+) -> AnyResult<ToolMeta, NexusCliError> {
+    let raw = if source == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| NexusCliError::Any(anyhow!("failed to read meta from stdin: {e}")))?;
+        buf
+    } else {
+        std::fs::read_to_string(source)
+            .map_err(|e| NexusCliError::Any(anyhow!("failed to read meta file '{source}': {e}")))?
+    };
+
+    let mut meta: ToolMeta = serde_json::from_str(&raw)
+        .map_err(|e| NexusCliError::Any(anyhow!("failed to parse meta JSON: {e}")))?;
+
+    if let Some(url) = url_override {
+        meta.url = url.to_string();
+    }
+
+    // Validate that meta.url is a syntactically valid URL. The live-endpoint
+    // path gets this for free via reqwest::Url parsing + an actual HTTP request;
+    // the --from-meta path must check explicitly to prevent registering tools
+    // with empty or malformed URLs on-chain.
+    reqwest::Url::parse(&meta.url).map_err(|e| {
+        NexusCliError::Any(anyhow!(
+            "tool meta contains an invalid URL '{}': {e}",
+            meta.url
+        ))
+    })?;
+
+    if meta.output_schema["oneOf"].is_null() {
+        return Err(NexusCliError::Any(anyhow!(
+            "The tool meta does not contain a top-level 'oneOf' key. Please make sure to use an enum as the Tool output type."
+        )));
+    }
+
+    Ok(meta)
+}
+
+/// Register a single tool from its already-validated `ToolMeta`.
+///
+/// Handles the "already registered" and "registration error" cases as non-fatal
+/// results so that batch mode can continue to the next tool. Fatal errors
+/// (e.g. missing OwnerCap in the response) are returned as `Err`.
+///
+/// On success, returns the JSON result and optionally the `(ToolFqn, ToolOwnerCaps)`
+/// pair for the caller to persist in `CliConf`.
+async fn register_one_tool(
+    meta: ToolMeta,
+    nexus_client: &NexusClient,
+    grpc_client: std::sync::Arc<tokio::sync::Mutex<sui::grpc::Client>>,
+    owner: sui::types::Address,
+    collateral_coin: Option<sui::types::Address>,
+    invocation_cost: u64,
+) -> AnyResult<(serde_json::Value, Option<(ToolFqn, ToolOwnerCaps)>), NexusCliError> {
+    let signer = nexus_client.signer();
+    let gas_config = nexus_client.gas_config();
+    let address = signer.get_active_address();
+    let nexus_objects = &*nexus_client.get_nexus_objects();
+    let collateral_coin = fetch_coin(grpc_client, owner, collateral_coin, 1).await?;
+
+    // Craft a TX to register the tool.
+    let tx_handle = loading!("Crafting transaction...");
+
+    let mut tx = sui::tx::TransactionBuilder::new();
+
+    if let Err(e) = tool::register_off_chain_for_self(
+        &mut tx,
+        nexus_objects,
+        &meta,
+        address,
+        &collateral_coin,
+        invocation_cost,
+    ) {
+        tx_handle.error();
+        return Err(NexusCliError::Any(e));
+    }
+
+    tx_handle.success();
+
+    let mut gas_coin = gas_config.acquire_gas_coin().await;
+
+    tx.set_sender(address);
+    tx.set_gas_budget(gas_config.get_budget());
+    tx.set_gas_price(nexus_client.get_reference_gas_price());
+
+    tx.add_gas_objects(vec![sui::tx::Input::owned(
+        *gas_coin.object_id(),
+        gas_coin.version(),
+        *gas_coin.digest(),
+    )]);
+
+    let tx = tx.finish().map_err(|e| NexusCliError::Any(e.into()))?;
+
+    let signature = signer.sign_tx(&tx).await.map_err(NexusCliError::Nexus)?;
+
+    // Sign and submit the TX.
+    let response = match signer.execute_tx(tx, signature, &mut gas_coin).await {
+        Ok(response) => {
+            gas_config.release_gas_coin(gas_coin).await;
+            response
+        }
+        // If the tool is already registered, treat as a non-fatal result so
+        // batch mode can continue to the next tool.
+        Err(NexusError::Wallet(e)) if e.to_string().contains("register_off_chain_tool_") => {
+            gas_config.release_gas_coin(gas_coin).await;
+
+            notify_error!(
+                "Tool '{fqn}' is already registered.",
+                fqn = meta.fqn.to_string().truecolor(100, 100, 100)
+            );
+
+            return Ok((
+                json!({
+                    "tool_fqn": meta.fqn,
+                    "already_registered": true,
+                }),
+                None,
+            ));
+        }
+        // Any other error is also non-fatal for batch mode.
+        Err(e) => {
+            gas_config.release_gas_coin(gas_coin).await;
+
+            notify_error!(
+                "Failed to register tool '{fqn}': {error}",
+                fqn = meta.fqn.to_string().truecolor(100, 100, 100),
+                error = e
+            );
+
+            return Ok((
+                json!({
+                    "tool_fqn": meta.fqn,
+                    "error": e.to_string(),
+                }),
+                None,
+            ));
+        }
+    };
+
+    // Parse the owner cap object IDs from the response.
+    let owner_caps = response
+        .objects
+        .iter()
+        .filter_map(|obj| {
+            let sui::types::ObjectType::Struct(object_type) = obj.object_type() else {
+                return None;
+            };
+
+            if *object_type.address() == nexus_objects.primitives_pkg_id
+                && *object_type.module() == primitives::OwnerCap::CLONEABLE_OWNER_CAP.module
+                && *object_type.name() == primitives::OwnerCap::CLONEABLE_OWNER_CAP.name
+            {
+                Some((obj.object_id(), object_type))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // Find `CloneableOwnerCap<OverTool>` object ID.
+    let over_tool = owner_caps.iter().find_map(|(object_id, object_type)| {
+        match object_type.type_params().first() {
+            Some(sui::types::TypeTag::Struct(what_for))
+                if *what_for.module() == workflow::ToolRegistry::OVER_TOOL.module
+                    && *what_for.name() == workflow::ToolRegistry::OVER_TOOL.name =>
+            {
+                Some(object_id)
+            }
+            _ => None,
+        }
+    });
+
+    let Some(over_tool_id) = over_tool else {
+        return Err(NexusCliError::Any(anyhow!(
+            "Could not find the OwnerCap<OverTool> object ID in the transaction response."
+        )));
+    };
+
+    // Find `CloneableOwnerCap<OverGas>` object ID.
+    let over_gas = owner_caps.iter().find_map(|(object_id, object_type)| {
+        match object_type.type_params().first() {
+            Some(sui::types::TypeTag::Struct(what_for))
+                if *what_for.module() == workflow::Gas::OVER_GAS.module
+                    && *what_for.name() == workflow::Gas::OVER_GAS.name =>
+            {
+                Some(object_id)
+            }
+            _ => None,
+        }
+    });
+
+    let Some(over_gas_id) = over_gas else {
+        return Err(NexusCliError::Any(anyhow!(
+            "Could not find the OwnerCap<OverGas> object ID in the transaction response."
+        )));
+    };
+
+    notify_success!(
+        "OwnerCap<OverTool> object ID: {id}",
+        id = over_tool_id.to_string().truecolor(100, 100, 100)
+    );
+
+    notify_success!(
+        "OwnerCap<OverGas> object ID: {id}",
+        id = over_gas_id.to_string().truecolor(100, 100, 100)
+    );
+
+    notify_success!(
+        "Transaction digest: {digest}",
+        digest = response.digest.to_string().truecolor(100, 100, 100)
+    );
+
+    let caps = ToolOwnerCaps {
+        over_tool: *over_tool_id,
+        over_gas: Some(*over_gas_id),
+    };
+
+    Ok((
+        json!({
+            "digest": response.digest,
+            "tool_fqn": meta.fqn,
+            "owner_cap_over_tool_id": over_tool_id,
+            "owner_cap_over_gas_id": over_gas_id,
+            "already_registered": false,
+        }),
+        Some((meta.fqn, caps)),
+    ))
+}
+
 /// Validate and then register a new offchain Tool.
+///
+/// When `from_meta` is provided, the tool metadata is read from a file or stdin
+/// instead of being fetched from a live HTTP endpoint. `url` overrides the URL
+/// field in the metadata when both are provided. `batch` and `from_meta` are
+/// mutually exclusive.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn register_off_chain_tool(
-    url: reqwest::Url,
+    url: Option<reqwest::Url>,
+    from_meta: Option<String>,
     collateral_coin: Option<sui::types::Address>,
     invocation_cost: u64,
     batch: bool,
@@ -26,29 +273,6 @@ pub(crate) async fn register_off_chain_tool(
     sui_gas_coin: Option<sui::types::Address>,
     sui_gas_budget: u64,
 ) -> AnyResult<(), NexusCliError> {
-    // Validate either a single tool or a batch of tools if the `batch` flag is
-    // provided.
-    let urls = if batch {
-        // Fetch all tools on the webserver.
-        let response = reqwest::Client::new()
-            .get(url.join("/tools").expect("Joining URL must be valid"))
-            .send()
-            .await
-            .map_err(NexusCliError::Http)?
-            .json::<Vec<String>>()
-            .await
-            .map_err(NexusCliError::Http)?;
-
-        response
-            .iter()
-            .filter_map(|s| url.join(s).ok())
-            .collect::<Vec<_>>()
-    } else {
-        vec![url]
-    };
-
-    let mut registration_results = Vec::with_capacity(urls.len());
-
     if collateral_coin.is_some() && collateral_coin == sui_gas_coin {
         return Err(NexusCliError::Any(anyhow!(
             "The coin used for collateral cannot be the same as the gas coin."
@@ -59,9 +283,14 @@ pub(crate) async fn register_off_chain_tool(
     let client = build_sui_grpc_client(&conf).await?;
     let pk = get_signing_key(&conf).await?;
     let owner = pk.public_key().derive_address();
+    let nexus_client = get_nexus_client(sui_gas_coin, sui_gas_budget).await?;
 
-    for tool_url in urls {
-        let meta = validate_off_chain_tool(tool_url).await?;
+    let mut registration_results = Vec::new();
+    let mut caps_to_save: Vec<(ToolFqn, ToolOwnerCaps)> = Vec::new();
+
+    if let Some(meta_source) = from_meta {
+        // Load metadata from file/stdin without hitting a live HTTP endpoint.
+        let meta = load_meta_from_source(&meta_source, url)?;
 
         command_title!(
             "Registering Tool '{fqn}' at '{url}'",
@@ -69,199 +298,220 @@ pub(crate) async fn register_off_chain_tool(
             url = meta.url
         );
 
-        let nexus_client = get_nexus_client(sui_gas_coin, sui_gas_budget).await?;
-        let signer = nexus_client.signer();
-        let gas_config = nexus_client.gas_config();
-        let address = signer.get_active_address();
-        let nexus_objects = &*nexus_client.get_nexus_objects();
-        let collateral_coin = fetch_coin(client.clone(), owner, collateral_coin, 1).await?;
-
-        // Craft a TX to register the tool.
-        let tx_handle = loading!("Crafting transaction...");
-
-        let mut tx = sui::tx::TransactionBuilder::new();
-
-        if let Err(e) = tool::register_off_chain_for_self(
-            &mut tx,
-            nexus_objects,
-            &meta,
-            address,
-            &collateral_coin,
+        let (result, caps) = register_one_tool(
+            meta,
+            &nexus_client,
+            client,
+            owner,
+            collateral_coin,
             invocation_cost,
-        ) {
-            tx_handle.error();
+        )
+        .await?;
 
+        registration_results.push(result);
+        caps_to_save.extend(caps);
+    } else {
+        // Live-endpoint path: require --url and optionally batch-discover tools.
+        let url = url.expect(
+            "--url is required when --from-meta is not provided (clap should enforce this)",
+        );
+
+        let urls = if batch {
+            // Fetch all tools on the webserver.
+            let response = reqwest::Client::new()
+                .get(url.join("/tools").expect("Joining URL must be valid"))
+                .send()
+                .await
+                .map_err(NexusCliError::Http)?
+                .json::<Vec<String>>()
+                .await
+                .map_err(NexusCliError::Http)?;
+
+            response
+                .iter()
+                .filter_map(|s| url.join(s).ok())
+                .collect::<Vec<_>>()
+        } else {
+            vec![url]
+        };
+
+        for tool_url in urls {
+            let meta = validate_off_chain_tool(tool_url).await?;
+
+            command_title!(
+                "Registering Tool '{fqn}' at '{url}'",
+                fqn = meta.fqn,
+                url = meta.url
+            );
+
+            let (result, caps) = register_one_tool(
+                meta,
+                &nexus_client,
+                client.clone(),
+                owner,
+                collateral_coin,
+                invocation_cost,
+            )
+            .await?;
+
+            registration_results.push(result);
+            caps_to_save.extend(caps);
+        }
+    }
+
+    // Persist all owner caps in a single load+save cycle.
+    if !no_save && !caps_to_save.is_empty() {
+        let save_handle = loading!("Saving the owner caps to the CLI configuration...");
+
+        let mut conf = CliConf::load().await.unwrap_or_default();
+        for (fqn, caps) in caps_to_save {
+            conf.tools.insert(fqn, caps);
+        }
+
+        if let Err(e) = conf.save().await {
+            save_handle.error();
             return Err(NexusCliError::Any(e));
         }
 
-        tx_handle.success();
-
-        let mut gas_coin = gas_config.acquire_gas_coin().await;
-
-        tx.set_sender(address);
-        tx.set_gas_budget(gas_config.get_budget());
-        tx.set_gas_price(nexus_client.get_reference_gas_price());
-
-        tx.add_gas_objects(vec![sui::tx::Input::owned(
-            *gas_coin.object_id(),
-            gas_coin.version(),
-            *gas_coin.digest(),
-        )]);
-
-        let tx = tx.finish().map_err(|e| NexusCliError::Any(e.into()))?;
-
-        let signature = signer.sign_tx(&tx).await.map_err(NexusCliError::Nexus)?;
-
-        // Sign and submit the TX.
-        let response = match signer.execute_tx(tx, signature, &mut gas_coin).await {
-            Ok(response) => {
-                gas_config.release_gas_coin(gas_coin).await;
-
-                response
-            }
-            // If the tool is already registered, we don't want to fail the
-            // command.
-            Err(NexusError::Wallet(e)) if e.to_string().contains("register_off_chain_tool_") => {
-                gas_config.release_gas_coin(gas_coin).await;
-
-                notify_error!(
-                    "Tool '{fqn}' is already registered.",
-                    fqn = meta.fqn.to_string().truecolor(100, 100, 100)
-                );
-
-                registration_results.push(json!({
-                    "tool_fqn": meta.fqn,
-                    "already_registered": true,
-                }));
-
-                continue;
-            }
-            // Any other error fails the tool registration but continues the
-            // loop.
-            Err(e) => {
-                gas_config.release_gas_coin(gas_coin).await;
-
-                notify_error!(
-                    "Failed to register tool '{fqn}': {error}",
-                    fqn = meta.fqn.to_string().truecolor(100, 100, 100),
-                    error = e
-                );
-
-                registration_results.push(json!({
-                    "tool_fqn": meta.fqn,
-                    "error": e.to_string(),
-                }));
-
-                continue;
-            }
-        };
-
-        // Parse the owner cap object IDs from the response.
-        let owner_caps = response
-            .objects
-            .iter()
-            .filter_map(|obj| {
-                let sui::types::ObjectType::Struct(object_type) = obj.object_type() else {
-                    return None;
-                };
-
-                if *object_type.address() == nexus_objects.primitives_pkg_id
-                    && *object_type.module() == primitives::OwnerCap::CLONEABLE_OWNER_CAP.module
-                    && *object_type.name() == primitives::OwnerCap::CLONEABLE_OWNER_CAP.name
-                {
-                    Some((obj.object_id(), object_type))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        // Find `CloneableOwnerCap<OverTool>` object ID.
-        let over_tool = owner_caps.iter().find_map(|(object_id, object_type)| {
-            match object_type.type_params().first() {
-                Some(sui::types::TypeTag::Struct(what_for))
-                    if *what_for.module() == workflow::ToolRegistry::OVER_TOOL.module
-                        && *what_for.name() == workflow::ToolRegistry::OVER_TOOL.name =>
-                {
-                    Some(object_id)
-                }
-                _ => None,
-            }
-        });
-
-        let Some(over_tool_id) = over_tool else {
-            return Err(NexusCliError::Any(anyhow!(
-                "Could not find the OwnerCap<OverTool> object ID in the transaction response."
-            )));
-        };
-
-        // Find `CloneableOwnerCap<OverGas>` object ID.
-        let over_gas = owner_caps.iter().find_map(|(object_id, object_type)| {
-            match object_type.type_params().first() {
-                Some(sui::types::TypeTag::Struct(what_for))
-                    if *what_for.module() == workflow::Gas::OVER_GAS.module
-                        && *what_for.name() == workflow::Gas::OVER_GAS.name =>
-                {
-                    Some(object_id)
-                }
-                _ => None,
-            }
-        });
-
-        let Some(over_gas_id) = over_gas else {
-            return Err(NexusCliError::Any(anyhow!(
-                "Could not find the OwnerCap<OverGas> object ID in the transaction response."
-            )));
-        };
-
-        notify_success!(
-            "OwnerCap<OverTool> object ID: {id}",
-            id = over_tool_id.to_string().truecolor(100, 100, 100)
-        );
-
-        notify_success!(
-            "OwnerCap<OverGas> object ID: {id}",
-            id = over_gas_id.to_string().truecolor(100, 100, 100)
-        );
-
-        notify_success!(
-            "Transaction digest: {digest}",
-            digest = response.digest.to_string().truecolor(100, 100, 100)
-        );
-
-        // Save the owner caps to the CLI conf.
-        if !no_save {
-            let save_handle = loading!("Saving the owner caps to the CLI configuration...");
-
-            let mut conf = CliConf::load().await.unwrap_or_default();
-
-            conf.tools.insert(
-                meta.fqn.clone(),
-                ToolOwnerCaps {
-                    over_tool: *over_tool_id,
-                    over_gas: Some(*over_gas_id),
-                },
-            );
-
-            if let Err(e) = conf.save().await {
-                save_handle.error();
-
-                return Err(NexusCliError::Any(e));
-            }
-
-            save_handle.success();
-        }
-
-        registration_results.push(json!({
-            "digest": response.digest,
-            "tool_fqn": meta.fqn,
-            "owner_cap_over_tool_id": over_tool_id,
-            "owner_cap_over_gas_id": over_gas_id,
-            "already_registered": false,
-        }))
+        save_handle.success();
     }
 
     json_output(&registration_results)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: returns a valid `ToolMeta` JSON string with the given URL.
+    fn valid_meta_json(url: &str) -> String {
+        serde_json::json!({
+            "fqn": "xyz.demo.tool@1",
+            "url": url,
+            "description": "A demo tool",
+            "timeout": 5000,
+            "input_schema": { "type": "object" },
+            "output_schema": { "oneOf": [{ "type": "string" }] }
+        })
+        .to_string()
+    }
+
+    /// Verifies that `load_meta_from_source` correctly reads and deserializes a
+    /// valid meta JSON file with all fields present.
+    /// Guards against regressions in the happy-path file read + JSON parse pipeline.
+    #[test]
+    fn load_meta_from_file_happy_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meta.json");
+        std::fs::write(&path, valid_meta_json("https://example.com")).unwrap();
+
+        let meta = load_meta_from_source(path.to_str().unwrap(), None).unwrap();
+
+        assert_eq!(meta.fqn.to_string(), "xyz.demo.tool@1");
+        assert_eq!(meta.url, "https://example.com");
+        assert_eq!(meta.description, "A demo tool");
+        assert_eq!(meta.timeout, std::time::Duration::from_millis(5000));
+    }
+
+    /// Verifies that `--url` override replaces the URL from the JSON file.
+    /// Guards against the url_override branch being accidentally removed.
+    #[test]
+    fn load_meta_url_override_replaces_file_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meta.json");
+        std::fs::write(&path, valid_meta_json("https://original.com")).unwrap();
+
+        let override_url = reqwest::Url::parse("https://override.com").unwrap();
+        let meta = load_meta_from_source(path.to_str().unwrap(), Some(override_url)).unwrap();
+
+        assert_eq!(meta.url, "https://override.com/");
+    }
+
+    /// Verifies that when `url_override` is `None`, the file's URL is preserved.
+    /// Guards against accidental URL clearing when no override is provided.
+    #[test]
+    fn load_meta_preserves_file_url_when_no_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meta.json");
+        std::fs::write(&path, valid_meta_json("https://preserved.com")).unwrap();
+
+        let meta = load_meta_from_source(path.to_str().unwrap(), None).unwrap();
+
+        assert_eq!(meta.url, "https://preserved.com");
+    }
+
+    /// Verifies that an empty URL in the meta file is rejected.
+    /// Guards against registering tools with empty URLs on-chain.
+    #[test]
+    fn load_meta_rejects_empty_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meta.json");
+        std::fs::write(&path, valid_meta_json("")).unwrap();
+
+        let err = load_meta_from_source(path.to_str().unwrap(), None).unwrap_err();
+        assert!(err.to_string().contains("invalid URL"), "got: {err}");
+    }
+
+    /// Verifies that a malformed URL in the meta file is rejected.
+    /// Guards against registering tools with non-URL strings on-chain.
+    #[test]
+    fn load_meta_rejects_malformed_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meta.json");
+        std::fs::write(&path, valid_meta_json("not a url")).unwrap();
+
+        let err = load_meta_from_source(path.to_str().unwrap(), None).unwrap_err();
+        assert!(err.to_string().contains("invalid URL"), "got: {err}");
+    }
+
+    /// Verifies that a meta file without `output_schema.oneOf` is rejected.
+    /// Guards against the oneOf validation being accidentally removed.
+    #[test]
+    fn load_meta_rejects_missing_one_of() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meta.json");
+
+        let json = serde_json::json!({
+            "fqn": "xyz.demo.tool@1",
+            "url": "https://example.com",
+            "description": "A demo tool",
+            "timeout": 5000,
+            "input_schema": { "type": "object" },
+            "output_schema": { "type": "object" }
+        })
+        .to_string();
+
+        std::fs::write(&path, json).unwrap();
+
+        let err = load_meta_from_source(path.to_str().unwrap(), None).unwrap_err();
+        assert!(err.to_string().contains("oneOf"), "got: {err}");
+    }
+
+    /// Verifies that malformed JSON is reported as a parse error.
+    /// Guards against silent acceptance of non-JSON input.
+    #[test]
+    fn load_meta_rejects_malformed_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meta.json");
+        std::fs::write(&path, "{ not valid json }").unwrap();
+
+        let err = load_meta_from_source(path.to_str().unwrap(), None).unwrap_err();
+        assert!(
+            err.to_string().contains("failed to parse meta JSON"),
+            "got: {err}"
+        );
+    }
+
+    /// Verifies that a non-existent file path produces an IO error.
+    /// Guards against silent fallback when the file doesn't exist.
+    #[test]
+    fn load_meta_rejects_nonexistent_file() {
+        let err = load_meta_from_source("/nonexistent/path/meta.json", None).unwrap_err();
+        assert!(
+            err.to_string().contains("failed to read meta file"),
+            "got: {err}"
+        );
+    }
 }

--- a/sdk/src/nexus/network_auth.rs
+++ b/sdk/src/nexus/network_auth.rs
@@ -59,6 +59,32 @@ pub struct RegisteredToolKey {
     pub binding_object_id: sui::types::Address,
 }
 
+/// An individual key entry returned by [`NetworkAuthActions::list_tool_keys`].
+#[derive(Clone, Debug)]
+pub struct ToolKeyEntry {
+    /// Key identifier (kid) used in signed HTTP claims.
+    pub kid: u64,
+    /// Hex-encoded Ed25519 public key.
+    pub public_key_hex: String,
+    /// Millisecond timestamp when the key was added.
+    pub added_at_ms: u64,
+    /// Whether the key has been revoked.
+    pub revoked: bool,
+}
+
+/// All registered keys for a specific tool, returned by [`NetworkAuthActions::list_tool_keys`].
+#[derive(Clone, Debug)]
+pub struct ToolKeyList {
+    /// On-chain object ID of the `KeyBinding` for this tool.
+    pub binding_object_id: sui::types::Address,
+    /// The currently active key ID, if any.
+    pub active_key_id: Option<u64>,
+    /// The next key ID that will be assigned on the next registration.
+    pub next_key_id: u64,
+    /// All key entries, sorted by kid ascending.
+    pub keys: Vec<ToolKeyEntry>,
+}
+
 pub struct NetworkAuthActions {
     pub(super) client: NexusClient,
 }
@@ -187,6 +213,59 @@ impl NetworkAuthActions {
             public_key,
             binding_object_id,
         })
+    }
+
+    /// Query all registered message-signing keys for a tool FQN.
+    ///
+    /// Returns `None` if the tool has no `KeyBinding` on-chain (no keys have ever been
+    /// registered for it). Returns `Some(list)` with the full key history otherwise.
+    pub async fn list_tool_keys(
+        &self,
+        tool_fqn: &ToolFqn,
+    ) -> Result<Option<ToolKeyList>, NexusError> {
+        let objects = &self.client.nexus_objects;
+        let codec =
+            NetworkAuthCodec::new(objects.workflow_pkg_id, *objects.network_auth.object_id());
+
+        let identity = IdentityKey::tool_fqn(&tool_fqn.to_string());
+        let binding_object_id = codec.binding_object_id(&identity)?;
+
+        let binding = match self.try_get_key_binding(binding_object_id).await? {
+            None => return Ok(None),
+            Some(b) => b,
+        };
+
+        let key_records = self
+            .client
+            .crawler()
+            .get_dynamic_fields_bcs::<u64, crate::types::KeyRecord>(
+                binding.data.keys.id,
+                binding.data.keys.size(),
+            )
+            .await
+            .map_err(|e| {
+                NexusError::Rpc(anyhow::anyhow!(
+                    "failed to fetch tool key records ({binding_object_id}): {e}"
+                ))
+            })?;
+
+        let mut keys: Vec<ToolKeyEntry> = key_records
+            .into_iter()
+            .map(|(kid, record)| ToolKeyEntry {
+                kid,
+                public_key_hex: hex::encode(&record.public_key),
+                added_at_ms: record.added_at_ms,
+                revoked: record.revoked_at_ms.is_some(),
+            })
+            .collect();
+        keys.sort_by_key(|k| k.kid);
+
+        Ok(Some(ToolKeyList {
+            binding_object_id,
+            active_key_id: binding.data.active_key_id,
+            next_key_id: binding.data.next_key_id,
+            keys,
+        }))
     }
 
     /// Export a tool-side allowlist file containing the active key for each leader.

--- a/sdk/src/nexus/network_auth.rs
+++ b/sdk/src/nexus/network_auth.rs
@@ -1355,5 +1355,191 @@ mod tests {
             let bytes = std::fs::read(&out_path).unwrap();
             assert_eq!(bytes, expected_bytes);
         }
+
+        /// Verifies that `list_tool_keys` returns the correct key list for a tool
+        /// with an active key and a revoked key, sorted by kid ascending.
+        /// Guards against regressions in the binding lookup, dynamic field
+        /// deserialization, key sorting, and revocation flag mapping.
+        #[tokio::test]
+        async fn list_tool_keys_returns_sorted_entries() {
+            let mut rng = rand::thread_rng();
+            let workflow_pkg_id = sui::types::Address::generate(&mut rng);
+            let network_auth_object_id = sui::types::Address::generate(&mut rng);
+
+            let tool_fqn_str = "xyz.demo.tool@1";
+            let tool_fqn: crate::ToolFqn = tool_fqn_str.parse().unwrap();
+
+            let codec = NetworkAuthCodec::new(workflow_pkg_id, network_auth_object_id);
+            let identity = IdentityKey::tool_fqn(tool_fqn_str);
+            let binding_object_id = codec.binding_object_id(&identity).unwrap();
+
+            let key_table_id = sui::types::Address::from_static("0x111");
+
+            // Two keys: kid=0 (revoked), kid=1 (active).
+            let record_0 = KeyRecord {
+                scheme: 0,
+                public_key: vec![0xaau8; 32],
+                added_at_ms: 1000,
+                revoked_at_ms: Some(2000),
+            };
+            let record_1 = KeyRecord {
+                scheme: 0,
+                public_key: vec![0xbbu8; 32],
+                added_at_ms: 3000,
+                revoked_at_ms: None,
+            };
+
+            let binding = KeyBinding {
+                id: sui::types::Address::from_static("0x222"),
+                identity: identity.clone(),
+                description: None,
+                next_key_id: 2,
+                active_key_id: Some(1),
+                keys: MoveTable::new(key_table_id, 2),
+            };
+
+            let binding_bytes = bcs::to_bytes(&binding).unwrap();
+
+            let field_0_id = sui::types::Address::from_static("0x333");
+            let field_1_id = sui::types::Address::from_static("0x444");
+
+            let field_0_value = DynamicFieldValueBcs {
+                id: sui::types::Address::from_static("0x555"),
+                name: 0u64,
+                value: record_0.clone(),
+            };
+            let field_1_value = DynamicFieldValueBcs {
+                id: sui::types::Address::from_static("0x666"),
+                name: 1u64,
+                value: record_1.clone(),
+            };
+            let field_0_bytes = bcs::to_bytes(&field_0_value).unwrap();
+            let field_1_bytes = bcs::to_bytes(&field_1_value).unwrap();
+
+            let mut ledger_service = sui_mocks::grpc::MockLedgerService::new();
+            let mut state_service = sui_mocks::grpc::MockStateService::new();
+
+            // Called once by NexusClientBuilder during initialization.
+            sui_mocks::grpc::mock_reference_gas_price(&mut ledger_service, 42);
+
+            // get_object: returns the binding (called by try_get_key_binding).
+            let binding_object_id_str = binding_object_id.to_string();
+            ledger_service
+                .expect_get_object()
+                .times(1)
+                .returning(move |request| {
+                    let requested_id = request.get_ref().object_id.as_deref().unwrap_or_default();
+                    if requested_id == binding_object_id_str {
+                        let object = object_with_contents(None, binding_bytes.clone());
+                        let mut response = sui::grpc::GetObjectResponse::default();
+                        response.object = Some(object);
+                        Ok(Response::new(response))
+                    } else {
+                        Err(Status::not_found(format!(
+                            "unexpected object id {requested_id}"
+                        )))
+                    }
+                });
+
+            // list_dynamic_fields: returns two field entries (kid=0 and kid=1).
+            // Return kid=1 first to verify the sort.
+            state_service
+                .expect_list_dynamic_fields()
+                .times(1)
+                .returning(move |_request| {
+                    let mut df1 = sui::grpc::DynamicField::default();
+                    df1.set_child_id(field_1_id);
+                    df1.set_field_id(field_1_id);
+                    let mut name1 = sui::grpc::Bcs::default();
+                    name1.value = Some(bcs::to_bytes(&1u64).unwrap().into());
+                    df1.set_name(name1);
+
+                    let mut df0 = sui::grpc::DynamicField::default();
+                    df0.set_child_id(field_0_id);
+                    df0.set_field_id(field_0_id);
+                    let mut name0 = sui::grpc::Bcs::default();
+                    name0.value = Some(bcs::to_bytes(&0u64).unwrap().into());
+                    df0.set_name(name0);
+
+                    let mut response = sui::grpc::ListDynamicFieldsResponse::default();
+                    response.dynamic_fields = vec![df1, df0];
+                    Ok(Response::new(response))
+                });
+
+            // batch_get_objects: returns both field values.
+            ledger_service
+                .expect_batch_get_objects()
+                .times(1)
+                .returning(move |_request| {
+                    let obj1 = object_with_contents(Some(field_1_id), field_1_bytes.clone());
+                    let mut r1 = sui::grpc::GetObjectResult::default();
+                    r1.result = Some(sui::grpc::get_object_result::Result::Object(obj1));
+
+                    let obj0 = object_with_contents(Some(field_0_id), field_0_bytes.clone());
+                    let mut r0 = sui::grpc::GetObjectResult::default();
+                    r0.result = Some(sui::grpc::get_object_result::Result::Object(obj0));
+
+                    let mut response = sui::grpc::BatchGetObjectsResponse::default();
+                    response.objects = vec![r1, r0];
+                    Ok(Response::new(response))
+                });
+
+            let rpc_url = sui_mocks::grpc::mock_server(sui_mocks::grpc::ServerMocks {
+                ledger_service_mock: Some(ledger_service),
+                state_service_mock: Some(state_service),
+                ..Default::default()
+            });
+
+            let pk = sui::crypto::Ed25519PrivateKey::generate(&mut rng);
+            let nexus_objects = crate::types::NexusObjects {
+                workflow_pkg_id,
+                primitives_pkg_id: sui::types::Address::generate(&mut rng),
+                interface_pkg_id: sui::types::Address::generate(&mut rng),
+                network_id: sui::types::Address::generate(&mut rng),
+                tool_registry: sui_mocks::mock_sui_object_ref(),
+                network_auth: sui::types::ObjectReference::new(
+                    network_auth_object_id,
+                    1,
+                    sui::types::Digest::generate(&mut rng),
+                ),
+                default_tap: sui_mocks::mock_sui_object_ref(),
+                gas_service: sui_mocks::mock_sui_object_ref(),
+                leader_registry: sui_mocks::mock_sui_object_ref(),
+                workflow_original_pkg_id: None,
+            };
+
+            let gas_coin = sui_mocks::mock_sui_object_ref();
+            let client = NexusClient::builder()
+                .with_private_key(pk)
+                .with_rpc_url(&rpc_url)
+                .with_nexus_objects(nexus_objects)
+                .with_gas(vec![gas_coin], 1_000_000)
+                .build()
+                .await
+                .unwrap();
+
+            let list = client
+                .network_auth()
+                .list_tool_keys(&tool_fqn)
+                .await
+                .unwrap()
+                .expect("binding exists, should return Some");
+
+            assert_eq!(list.binding_object_id, binding_object_id);
+            assert_eq!(list.active_key_id, Some(1));
+            assert_eq!(list.next_key_id, 2);
+            assert_eq!(list.keys.len(), 2);
+
+            // Sorted by kid ascending.
+            assert_eq!(list.keys[0].kid, 0);
+            assert_eq!(list.keys[0].public_key_hex, hex::encode([0xaau8; 32]));
+            assert_eq!(list.keys[0].added_at_ms, 1000);
+            assert!(list.keys[0].revoked);
+
+            assert_eq!(list.keys[1].kid, 1);
+            assert_eq!(list.keys[1].public_key_hex, hex::encode([0xbbu8; 32]));
+            assert_eq!(list.keys[1].added_at_ms, 3000);
+            assert!(!list.keys[1].revoked);
+        }
     }
 }

--- a/toolkit-rust/src/lib.rs
+++ b/toolkit-rust/src/lib.rs
@@ -29,3 +29,6 @@ pub use {
     serde_tracked::*,
     warp::{self, http::StatusCode},
 };
+// Re-exported for use by the `bootstrap!` macro. Not part of the public API.
+#[doc(hidden)]
+pub use {reqwest, serde_json};

--- a/toolkit-rust/src/runtime.rs
+++ b/toolkit-rust/src/runtime.rs
@@ -29,6 +29,26 @@ pub fn load_config_() -> anyhow::Result<Arc<ToolkitRuntimeConfig>> {
     ToolkitRuntimeConfig::from_env().map(Arc::new)
 }
 
+/// Build a placeholder URL for `--meta` output from a tool's [`NexusTool::path()`].
+///
+/// The URL is a `http://localhost`-based placeholder — the real URL is set
+/// during registration via `--url`. This function normalises the path so that
+/// a missing leading `/` does not corrupt the URL's authority component.
+///
+/// **This is an internal function used by [bootstrap!] macro and should not be
+/// used directly.**
+#[doc(hidden)]
+pub fn meta_placeholder_url_(path: &str) -> Url {
+    let base = if path.is_empty() {
+        "http://localhost/".to_string()
+    } else if path.starts_with('/') {
+        format!("http://localhost{path}")
+    } else {
+        format!("http://localhost/{path}")
+    };
+    Url::parse(&base).expect("placeholder URL must be valid")
+}
+
 fn json_bytes_or_fallback(status: StatusCode, value: serde_json::Value) -> (StatusCode, Vec<u8>) {
     match serde_json::to_vec(&value) {
         Ok(body) => (status, body),
@@ -78,6 +98,16 @@ fn json_bytes_or_fallback(status: StatusCode, value: serde_json::Value) -> (Stat
 ///     }
 ///   }
 /// }
+/// ```
+///
+/// ## `--meta` flag
+/// When the binary is invoked with `--meta`, the macro prints a JSON array of
+/// tool metadata (one entry per tool) to stdout and exits immediately — no HTTP
+/// server is started. This is used by CI pipelines to extract registration data
+/// from a Docker image without running the tool.
+///
+/// ```shell
+/// ./my-tool --meta   # prints JSON array and exits
 /// ```
 ///
 /// ## Request body limits
@@ -140,6 +170,28 @@ macro_rules! bootstrap {
     }};
     ($addr:expr, [$tool:ty $(, $next_tool:ty)* $(,)?]) => {{
         let _ = $crate::env_logger::try_init();
+
+        // Handle --meta: print tool metadata as a JSON array and exit
+        // without starting the HTTP server. Used by CI to extract
+        // registration data from a Docker image. Uses `return` to exit
+        // the enclosing function (typically `main`).
+        if ::std::env::args().any(|a| a == "--meta") {
+            let meta = $crate::serde_json::json!([
+                <$tool as $crate::NexusTool>::meta(
+                    $crate::runtime::meta_placeholder_url_(<$tool as $crate::NexusTool>::path())
+                )
+                $(
+                    , <$next_tool as $crate::NexusTool>::meta(
+                        $crate::runtime::meta_placeholder_url_(<$next_tool as $crate::NexusTool>::path())
+                    )
+                )*
+            ]);
+
+            println!("{}", $crate::serde_json::to_string_pretty(&meta)
+                .expect("meta serialization must not fail"));
+            return;
+        }
+
         use {
             ::std::sync::Arc,
             $crate::warp::{http::StatusCode, Filter},
@@ -777,5 +829,42 @@ mod tests {
 
         // Cleanup
         let _ = fs::remove_file(&path);
+    }
+
+    /// Verifies that an empty path produces `http://localhost/`.
+    /// Guards against the default `NexusTool::path()` returning `""` being
+    /// mishandled (e.g., producing `http://localhost` without trailing slash).
+    #[test]
+    fn meta_placeholder_url_empty_path() {
+        let url = super::meta_placeholder_url_("");
+        assert_eq!(url.as_str(), "http://localhost/");
+    }
+
+    /// Verifies that a path without a leading slash gets one inserted.
+    /// Guards against `format!("http://localhost{path}")` producing a URL
+    /// whose authority is `localhostpath` instead of `localhost`.
+    #[test]
+    fn meta_placeholder_url_no_leading_slash() {
+        let url = super::meta_placeholder_url_("path");
+        assert_eq!(url.host_str(), Some("localhost"));
+        assert_eq!(url.path(), "/path");
+    }
+
+    /// Verifies that a path with a leading slash is used as-is.
+    /// Guards against double-slash (`//path`) when the slash is already present.
+    #[test]
+    fn meta_placeholder_url_with_leading_slash() {
+        let url = super::meta_placeholder_url_("/foo/");
+        assert_eq!(url.host_str(), Some("localhost"));
+        assert_eq!(url.path(), "/foo/");
+    }
+
+    /// Verifies that a path with a leading slash and no trailing slash works.
+    /// Guards against off-by-one in the slash normalization logic.
+    #[test]
+    fn meta_placeholder_url_leading_slash_no_trailing() {
+        let url = super::meta_placeholder_url_("/foo");
+        assert_eq!(url.host_str(), Some("localhost"));
+        assert_eq!(url.path(), "/foo");
     }
 }


### PR DESCRIPTION
## Summary

Closes #434, closes #435.

- **`register offchain --from-meta <FILE|->`**: Register a tool from a JSON metadata file (or stdin) without hitting a live HTTP endpoint. Validates URL syntax and `output_schema.oneOf` before submission. `--url` can optionally override the URL in the file. Mutually exclusive with `--batch`.
- **`tool auth list-keys --tool-fqn <FQN>`**: Query and display all registered message-signing keys for a tool (key ID, public key, timestamp, revocation status).
- **`tool auth register-key --skip-if-active`**: Skip the on-chain registration if the same public key is already the active key. Designed for idempotent CI pipelines.
- **`bootstrap!` macro `--meta` flag**: When a tool binary is invoked with `--meta`, it prints a JSON array of tool metadata to stdout and exits without starting the HTTP server. Eliminates the boilerplate each tool currently duplicates for CI registration pipelines.
- Updated `CHANGELOG.md` with all changes under `[Unreleased]`.

### SDK changes

- Added `ToolKeyEntry` and `ToolKeyList` types to `sdk/src/nexus/network_auth.rs`
- Added `list_tool_keys()` method to `NetworkAuthActions`

### Toolkit changes

- `bootstrap!` macro handles `--meta` automatically — no per-tool boilerplate needed
- `reqwest` and `serde_json` re-exported as `#[doc(hidden)]` for macro support

### Notable design decisions

- `--from-meta` validates URL syntax (`reqwest::Url::parse`) but intentionally skips the live HTTP health check — that's the whole point of the flag.
- `--skip-if-active` is best-effort: concurrent invocations may both bypass the check (TOCTOU). The on-chain contract prevents corruption but not duplicate key entries. This is acceptable for single-pipeline CI usage.
- Batch registration reuses a single `NexusClient` and performs a single `CliConf` load+save cycle (not per-tool).
- `--meta` output is always a JSON array (even for a single tool) for consistent consumer-side parsing. The `url` field uses a `http://localhost/` placeholder — the real URL is set during registration via `--url`.