### PR TITLE
docs: add mainnet/testnet tabs to setup guide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ nexus-toolkit = { path = "toolkit-rust" }
 nexus-sdk = { path = "sdk" }
 
 [profile.release]
-# debug = 1 means line charts only, which is minimum needed for good stack traces
+# debug = 1 means line tables only, which is minimum needed for good stack traces
 debug = 1
 # Write debug info into a separate file.
 split-debuginfo = "packed"

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -52,15 +52,19 @@ nexus --version
 
 {% tabs %}
 {% tab title="Testnet" %}
+
 ```bash
 wget -O ~/.nexus/objects.testnet.toml https://storage.googleapis.com/production-talus-sui-objects/v0.8.4/objects.testnet.toml
 ```
+
 {% endtab %}
 
 {% tab title="Mainnet" %}
+
 ```bash
 wget -O ~/.nexus/objects.mainnet.toml https://storage.googleapis.com/production-talus-sui-objects/v0.8.4/objects.mainnet.toml
 ```
+
 {% endtab %}
 {% endtabs %}
 
@@ -75,6 +79,7 @@ nexus conf set \
   --sui.rpc-url https://fullnode.testnet.sui.io \
   --nexus.objects ~/.nexus/objects.testnet.toml
 ```
+
 {% endtab %}
 
 {% tab title="Mainnet" %}
@@ -85,6 +90,7 @@ nexus conf set \
   --sui.rpc-url https://fullnode.mainnet.sui.io \
   --nexus.objects ~/.nexus/objects.mainnet.toml
 ```
+
 {% endtab %}
 {% endtabs %}
 
@@ -103,17 +109,21 @@ sui client --yes
 
 {% tabs %}
 {% tab title="Testnet" %}
+
 ```bash
 sui client new-env --alias testnet --rpc https://fullnode.testnet.sui.io
 sui client switch --env testnet
 ```
+
 {% endtab %}
 
 {% tab title="Mainnet" %}
+
 ```bash
 sui client new-env --alias mainnet --rpc https://fullnode.mainnet.sui.io
 sui client switch --env mainnet
 ```
+
 {% endtab %}
 {% endtabs %}
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -1,6 +1,6 @@
 # Nexus SDK Developer Setup Guide
 
-This guide will help you quickly set up your development environment and start using Nexus SDK, including initializing your wallet, funding it through a faucet, and accessing the `testnet` Sui explorer.
+This guide will help you quickly set up your development environment and start using Nexus SDK, including initializing your wallet, funding it, and accessing the Sui explorer.
 
 ## Installation and Setup
 
@@ -50,12 +50,24 @@ nexus --version
 
 ## Download the Nexus objects
 
+{% tabs %}
+{% tab title="Testnet" %}
 ```bash
 wget -O ~/.nexus/objects.testnet.toml https://storage.googleapis.com/production-talus-sui-objects/v0.8.4/objects.testnet.toml
 ```
+{% endtab %}
 
-## Configure the Sui testnet
+{% tab title="Mainnet" %}
+```bash
+wget -O ~/.nexus/objects.mainnet.toml https://storage.googleapis.com/production-talus-sui-objects/v0.8.4/objects.mainnet.toml
+```
+{% endtab %}
+{% endtabs %}
 
+## Configure the Sui network
+
+{% tabs %}
+{% tab title="Testnet" %}
 Configure your Nexus CLI to connect to the Sui `testnet` by running:
 
 ```bash
@@ -63,10 +75,22 @@ nexus conf set \
   --sui.rpc-url https://fullnode.testnet.sui.io \
   --nexus.objects ~/.nexus/objects.testnet.toml
 ```
+{% endtab %}
+
+{% tab title="Mainnet" %}
+Configure your Nexus CLI to connect to the Sui `mainnet` by running:
+
+```bash
+nexus conf set \
+  --sui.rpc-url https://fullnode.mainnet.sui.io \
+  --nexus.objects ~/.nexus/objects.mainnet.toml
+```
+{% endtab %}
+{% endtabs %}
 
 ### Configure the Sui client
 
-After installing the Sui binaries, configure and activate your Sui `testnet` environment:
+After installing the Sui binaries, configure and activate your Sui environment:
 
 {% hint style="info" %}
 Assuming you have no prior sui configuration
@@ -77,12 +101,23 @@ sui client --yes
 
 {% endhint %}
 
+{% tabs %}
+{% tab title="Testnet" %}
 ```bash
 sui client new-env --alias testnet --rpc https://fullnode.testnet.sui.io
 sui client switch --env testnet
 ```
+{% endtab %}
 
-## Create a wallet and request funds from the faucet
+{% tab title="Mainnet" %}
+```bash
+sui client new-env --alias mainnet --rpc https://fullnode.mainnet.sui.io
+sui client switch --env mainnet
+```
+{% endtab %}
+{% endtabs %}
+
+## Create a wallet and fund it
 
 Create a new wallet with the following command:
 
@@ -103,7 +138,15 @@ BASE64_PK=$(sui keytool convert "$PK" --json | jq -er '.base64WithFlag')
 nexus conf set --sui.pk "$BASE64_PK"
 ```
 
+{% tabs %}
+{% tab title="Testnet" %}
 Request funds from the faucet by visiting [Sui faucet](https://faucet.sui.io/) and entering your wallet address. You'll need at least 2 coins: one for the Nexus gas budget and one for transaction gas fees.
+{% endtab %}
+
+{% tab title="Mainnet" %}
+You will need SUI tokens to pay for transaction gas fees and the Nexus gas budget. Acquire SUI through an exchange and transfer to your wallet address.
+{% endtab %}
+{% endtabs %}
 
 To check the balance, run:
 


### PR DESCRIPTION
## Summary
- Add GitBook `{% tabs %}` toggles to the setup guide so users can switch between **mainnet** and **testnet** instructions
- Network-specific sections: objects download, Nexus CLI config, Sui client config, wallet funding
- Network-agnostic steps (CLI installation, wallet creation, gas budget) remain shared
- Rename section headers to be network-neutral ("Configure the Sui network", "Create a wallet and fund it")

## Test plan
- [ ] Verify tabs render correctly on GitBook
- [ ] Confirm mainnet objects URL resolves
- [ ] Walk through both testnet and mainnet flows end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)