### PR TITLE
Patch for Additional events and objects for Integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Added
 
+- `PaymentLockUpdateEvent` parsing is now allowed from public workflow/TAP calls emitted through non-Nexus caller packages, with regression coverage for the wrapped event shape used by cap-gated standard TAP executions.
+- SDK models now expose scheduled TAP task and occurrence context from `DAGExecution`, so execution inspection and payment recovery can identify the scheduled task that funded a walk.
+- `ExecutionCostResult` now reports the standard TAP payment object, locked budget, consumed amount, outstanding vertex locks, and terminal accomplishment/refund status from execution-owned payment state.
+- PTB helpers now cover vertex authorization grant creation and active-walk authorization-check-cap minting for cap-gated on-chain tools.
 - `TerminalErrEvalRecordedEvent` and `SubmissionFailureEvidenceRecordedEvent` SDK event types.
 - Nested Move-JSON parsers for terminal `_err_eval` records and submission failure evidence, including wrapper, option, enum, address, runtime-vertex, byte-vector, and normalized string forms.
 - Workflow failure model types, including `FailureEvidenceKind`, `WorkflowFailureClass`, `PostFailureAction`, and `ExecutionTerminalRecord`.
@@ -45,6 +49,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Changed
 
+- Workflow object decoding now treats the standard TAP execution context as complete only when agent, skill, endpoint revision, payment, selected DAG, authorization plan, and scheduled occurrence fields are consistent.
+- `VertexAuthorizationGrantCreatedEvent` and `WorkflowVertexAuthorizationGrant` now use `execution_id`, matching the current Move object/event layout.
+- Default DAG execution helpers prefer the configured `default_tap_target` when it resolves to a runtime-selected active skill, then fall back to registry recovery.
 - `full` and `nexus` no longer enable `move_publish`; package publishing APIs now require the explicit `move_publish` feature, and the CLI opts into it for deployment commands.
 - Optimized nested event value parsing with improved performance and reduced redundant checks
 - Made `parse_nested_event_value` public for use in nested event parsing

--- a/sdk/src/events/mod.rs
+++ b/sdk/src/events/mod.rs
@@ -464,7 +464,7 @@ pub struct AgentSkillExecutionRequestedEvent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VertexAuthorizationGrantCreatedEvent {
     pub grant_id: sui::types::Address,
-    pub walk_execution_id: sui::types::Address,
+    pub execution_id: sui::types::Address,
     pub vertex: RuntimeVertex,
 }
 

--- a/sdk/src/events/parsing.rs
+++ b/sdk/src/events/parsing.rs
@@ -506,6 +506,7 @@ fn allows_foreign_emitter(event_name: &str) -> bool {
             // Nexus functions invoked from a package-owned PTB.
             | "AgentSkillExecutionRequestedEvent"
             | "AgentSkillPaymentCreatedEvent"
+            | "PaymentLockUpdateEvent"
             | "RequestScheduledWalkEvent"
             | "RequestWalkExecutionEvent"
             | "VertexAuthorizationGrantCreatedEvent"
@@ -1177,7 +1178,7 @@ mod tests {
             "VertexAuthorizationGrantCreatedEvent",
             VertexAuthorizationGrantCreatedEvent {
                 grant_id: sui::types::Address::from_static("0x44"),
-                walk_execution_id: sui::types::Address::from_static("0x45"),
+                execution_id: sui::types::Address::from_static("0x45"),
                 vertex: RuntimeVertex::plain("transfer"),
             },
         );
@@ -1241,6 +1242,29 @@ mod tests {
                 request,
                 ..
             }) if request.next_vertex == RuntimeVertex::plain("transfer")
+        ));
+
+        let lock_event = wrapped_nexus_event(
+            &objects,
+            emitter_package,
+            objects.workflow_pkg_id,
+            "gas",
+            "PaymentLockUpdateEvent",
+            PaymentLockUpdateEvent {
+                execution: sui::types::Address::from_static("0x56"),
+                vertex: RuntimeVertex::plain("transfer"),
+                tool_fqn: crate::fqn!("demo.taluslabs.demo_onchain_vertex@1"),
+                was_locked: true,
+            },
+        );
+        let parsed = NexusEvent::from_sui_grpc_event(4, digest, &lock_event, &objects).unwrap();
+        assert!(matches!(
+            parsed.data,
+            NexusEventKind::PaymentLockUpdate(PaymentLockUpdateEvent {
+                vertex,
+                was_locked: true,
+                ..
+            }) if vertex == RuntimeVertex::plain("transfer")
         ));
     }
 

--- a/sdk/src/nexus/crawler.rs
+++ b/sdk/src/nexus/crawler.rs
@@ -2,7 +2,10 @@
 //! and dynamic field data from Sui GRPC and deserialize them into Rust structs.
 
 use {
-    crate::sui::{self, traits::FieldMaskUtil},
+    crate::{
+        sui::{self, traits::FieldMaskUtil},
+        types::strip_fields_owned,
+    },
     anyhow::{anyhow, bail},
     serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize},
     std::{
@@ -1431,9 +1434,51 @@ impl<V> ValueOrWrapper<V> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+fn strip_dynamic_value_owned(value: serde_json::Value) -> serde_json::Value {
+    let value = strip_fields_owned(value);
+    let serde_json::Value::Object(mut object) = value else {
+        return value;
+    };
+
+    if let Some(inner) = object.remove("value") {
+        object.insert("value".to_string(), strip_fields_owned(inner));
+    }
+
+    serde_json::Value::Object(object)
+}
+
+#[derive(Clone, Debug)]
 struct DynamicValue<V> {
     value: ValueOrWrapper<V>,
+}
+
+impl<'de, V> Deserialize<'de> for DynamicValue<V>
+where
+    V: DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawDynamicValue {
+            value: serde_json::Value,
+        }
+
+        if !deserializer.is_human_readable() {
+            #[derive(Deserialize)]
+            struct BcsDynamicValue<V> {
+                value: ValueOrWrapper<V>,
+            }
+
+            return BcsDynamicValue::deserialize(deserializer).map(|raw| Self { value: raw.value });
+        }
+
+        let raw = RawDynamicValue::deserialize(deserializer)?;
+        let value = strip_dynamic_value_owned(raw.value);
+        let value = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        Ok(Self { value })
+    }
 }
 
 // == Helper functions ==
@@ -1651,6 +1696,187 @@ mod tests {
 
         assert_eq!(object.object_id, *child_ref.object_id());
         assert_eq!(object.data, TestValue { value: 11 });
+    }
+
+    #[tokio::test]
+    async fn get_dynamic_fields_accepts_fields_wrapped_values() {
+        let parent =
+            DynamicMap::<TestKey, TestValue>::new(sui::types::Address::from_static("0x70"), 1);
+        let key = TestKey {
+            name: "wanted".to_string(),
+        };
+        let field_ref = sui_mocks::object_ref_for_id(sui::types::Address::from_static("0x71"));
+        let json = json!({
+            "id": field_ref.object_id(),
+            "name": key,
+            "value": {
+                "fields": {
+                    "value": 42
+                }
+            }
+        });
+
+        let mut state_service_mock = sui_mocks::grpc::MockStateService::new();
+        sui_mocks::grpc::mock_list_dynamic_fields(
+            &mut state_service_mock,
+            vec![(key.clone(), *field_ref.object_id())],
+        );
+        let mut ledger_service_mock = sui_mocks::grpc::MockLedgerService::new();
+        ledger_service_mock
+            .expect_batch_get_objects()
+            .times(1)
+            .with(always())
+            .returning(move |_| {
+                let object = object_with_json(
+                    field_ref.clone(),
+                    sui::types::Owner::Shared(1),
+                    json.clone(),
+                );
+                let mut result = sui::grpc::GetObjectResult::default();
+                result.set_object(object);
+                let mut response = sui::grpc::BatchGetObjectsResponse::default();
+                response.set_objects(vec![result]);
+                Ok(tonic::Response::new(response))
+            });
+
+        let rpc_url = sui_mocks::grpc::mock_server(sui_mocks::grpc::ServerMocks {
+            ledger_service_mock: Some(ledger_service_mock),
+            state_service_mock: Some(state_service_mock),
+            ..Default::default()
+        });
+        let client = sui::grpc::Client::new(rpc_url).expect("mock client");
+        let crawler = Crawler::new(Arc::new(Mutex::new(client)));
+
+        let fields = crawler
+            .get_dynamic_fields(&parent)
+            .await
+            .expect("wrapped dynamic field value decodes");
+
+        assert_eq!(fields.get(&key), Some(&TestValue { value: 42 }));
+    }
+
+    #[tokio::test]
+    async fn get_dynamic_fields_accepts_linked_table_node_wrapped_values() {
+        let parent =
+            DynamicMap::<TestKey, TestValue>::new(sui::types::Address::from_static("0x72"), 1);
+        let key = TestKey {
+            name: "node".to_string(),
+        };
+        let field_ref = sui_mocks::object_ref_for_id(sui::types::Address::from_static("0x73"));
+        let json = json!({
+            "id": field_ref.object_id(),
+            "name": key,
+            "value": {
+                "type": "0x2::linked_table::Node<test::TestKey, test::TestValue>",
+                "fields": {
+                    "next": null,
+                    "prev": null,
+                    "value": {
+                        "type": "test::TestValue",
+                        "fields": {
+                            "value": 42
+                        }
+                    }
+                }
+            }
+        });
+
+        let mut state_service_mock = sui_mocks::grpc::MockStateService::new();
+        sui_mocks::grpc::mock_list_dynamic_fields(
+            &mut state_service_mock,
+            vec![(key.clone(), *field_ref.object_id())],
+        );
+        let mut ledger_service_mock = sui_mocks::grpc::MockLedgerService::new();
+        ledger_service_mock
+            .expect_batch_get_objects()
+            .times(1)
+            .with(always())
+            .returning(move |_| {
+                let object = object_with_json(
+                    field_ref.clone(),
+                    sui::types::Owner::Shared(1),
+                    json.clone(),
+                );
+                let mut result = sui::grpc::GetObjectResult::default();
+                result.set_object(object);
+                let mut response = sui::grpc::BatchGetObjectsResponse::default();
+                response.set_objects(vec![result]);
+                Ok(tonic::Response::new(response))
+            });
+
+        let rpc_url = sui_mocks::grpc::mock_server(sui_mocks::grpc::ServerMocks {
+            ledger_service_mock: Some(ledger_service_mock),
+            state_service_mock: Some(state_service_mock),
+            ..Default::default()
+        });
+        let client = sui::grpc::Client::new(rpc_url).expect("mock client");
+        let crawler = Crawler::new(Arc::new(Mutex::new(client)));
+
+        let fields = crawler
+            .get_dynamic_fields(&parent)
+            .await
+            .expect("linked-table dynamic field value decodes");
+
+        assert_eq!(fields.get(&key), Some(&TestValue { value: 42 }));
+    }
+
+    #[tokio::test]
+    async fn get_dynamic_fields_accepts_sui_linked_table_node_json() {
+        let parent =
+            DynamicMap::<TestKey, TestValue>::new(sui::types::Address::from_static("0x74"), 1);
+        let key = TestKey {
+            name: "node".to_string(),
+        };
+        let field_ref = sui_mocks::object_ref_for_id(sui::types::Address::from_static("0x75"));
+        let json = json!({
+            "id": field_ref.object_id(),
+            "name": key,
+            "value": {
+                "next": null,
+                "prev": null,
+                "value": {
+                    "value": 42
+                }
+            }
+        });
+
+        let mut state_service_mock = sui_mocks::grpc::MockStateService::new();
+        sui_mocks::grpc::mock_list_dynamic_fields(
+            &mut state_service_mock,
+            vec![(key.clone(), *field_ref.object_id())],
+        );
+        let mut ledger_service_mock = sui_mocks::grpc::MockLedgerService::new();
+        ledger_service_mock
+            .expect_batch_get_objects()
+            .times(1)
+            .with(always())
+            .returning(move |_| {
+                let object = object_with_json(
+                    field_ref.clone(),
+                    sui::types::Owner::Shared(1),
+                    json.clone(),
+                );
+                let mut result = sui::grpc::GetObjectResult::default();
+                result.set_object(object);
+                let mut response = sui::grpc::BatchGetObjectsResponse::default();
+                response.set_objects(vec![result]);
+                Ok(tonic::Response::new(response))
+            });
+
+        let rpc_url = sui_mocks::grpc::mock_server(sui_mocks::grpc::ServerMocks {
+            ledger_service_mock: Some(ledger_service_mock),
+            state_service_mock: Some(state_service_mock),
+            ..Default::default()
+        });
+        let client = sui::grpc::Client::new(rpc_url).expect("mock client");
+        let crawler = Crawler::new(Arc::new(Mutex::new(client)));
+
+        let fields = crawler
+            .get_dynamic_fields(&parent)
+            .await
+            .expect("linked-table Sui JSON dynamic field value decodes");
+
+        assert_eq!(fields.get(&key), Some(&TestValue { value: 42 }));
     }
 
     #[tokio::test]

--- a/sdk/src/nexus/models.rs
+++ b/sdk/src/nexus/models.rs
@@ -11,19 +11,21 @@ use {
             AgentId,
             InterfaceRevision,
             MoveOption,
+            MoveVecSet,
             NexusData,
             SkillId,
             TapVertexAuthorizationPlan,
             TapVertexAuthorizationPlanEntry,
             TypeName,
             VerifierConfig,
+            VerifierMode,
         },
         ToolFqn,
     },
-    anyhow::bail,
+    anyhow::{anyhow, bail},
     serde::{Deserialize, Serialize},
     serde_json::Value,
-    std::collections::HashMap,
+    std::collections::{HashMap, HashSet},
 };
 
 /// Struct holding the DAG definition from our Move code.
@@ -169,6 +171,120 @@ impl DagVertexKind {
             DagVertexKind::OnChain { tool_fqn } => tool_fqn,
         }
     }
+}
+
+/// BCS-facing DAG vertex metadata used for linked-table dynamic-field decoding.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct DagVertexInfoBcs {
+    pub(crate) kind: DagVertexKindBcs,
+    pub(crate) input_ports: MoveVecSet<DagInputPort>,
+    #[allow(dead_code)]
+    pub(crate) post_failure_action: MoveOption<PostFailureActionBcs>,
+    pub(crate) leader_verifier: MoveOption<VerifierConfigBcs>,
+    pub(crate) tool_verifier: MoveOption<VerifierConfigBcs>,
+}
+
+impl DagVertexInfoBcs {
+    pub(crate) fn into_sdk(self) -> anyhow::Result<DagVertexInfo> {
+        let input_ports = self
+            .input_ports
+            .contents
+            .into_iter()
+            .collect::<HashSet<_>>();
+        Ok(DagVertexInfo {
+            kind: self.kind.into_sdk()?,
+            leader_verifier: self
+                .leader_verifier
+                .0
+                .map(VerifierConfigBcs::into_sdk)
+                .transpose()?,
+            tool_verifier: self
+                .tool_verifier
+                .0
+                .map(VerifierConfigBcs::into_sdk)
+                .transpose()?,
+            input_ports: input_ports.into_iter().collect(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum DagVertexKindBcs {
+    OnChain {
+        #[allow(dead_code)]
+        _variant_name: String,
+        tool_fqn: String,
+    },
+    OffChain {
+        #[allow(dead_code)]
+        _variant_name: String,
+        tool_fqn: String,
+    },
+}
+
+impl DagVertexKindBcs {
+    fn into_sdk(self) -> anyhow::Result<DagVertexKind> {
+        match self {
+            Self::OnChain { tool_fqn, .. } => Ok(DagVertexKind::OnChain {
+                tool_fqn: parse_dag_tool_fqn(tool_fqn)?,
+            }),
+            Self::OffChain { tool_fqn, .. } => Ok(DagVertexKind::OffChain {
+                tool_fqn: parse_dag_tool_fqn(tool_fqn)?,
+            }),
+        }
+    }
+}
+
+fn parse_dag_tool_fqn(value: String) -> anyhow::Result<ToolFqn> {
+    value
+        .parse::<ToolFqn>()
+        .map_err(|error| anyhow!("DAG BCS tool FQN '{value}' did not parse: {error}"))
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct VerifierConfigBcs {
+    mode: VerifierModeBcs,
+    method: String,
+}
+
+impl VerifierConfigBcs {
+    fn into_sdk(self) -> anyhow::Result<VerifierConfig> {
+        Ok(VerifierConfig {
+            mode: match self.mode {
+                VerifierModeBcs::None => VerifierMode::None,
+                VerifierModeBcs::LeaderRegisteredKey => VerifierMode::LeaderRegisteredKey,
+                VerifierModeBcs::ToolVerifierContract => VerifierMode::ToolVerifierContract,
+            },
+            method: self.method,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum VerifierModeBcs {
+    None,
+    LeaderRegisteredKey,
+    ToolVerifierContract,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum PostFailureActionBcs {
+    Terminate,
+    TransientContinue,
+}
+
+/// BCS-facing `sui::linked_table::Node<K, V>`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(bound(
+    deserialize = "K: serde::de::DeserializeOwned, V: serde::de::DeserializeOwned",
+    serialize = "K: Serialize, V: Serialize"
+))]
+pub(crate) struct LinkedTableNodeBcs<K, V> {
+    #[allow(dead_code)]
+    pub(crate) prev: MoveOption<K>,
+    #[allow(dead_code)]
+    pub(crate) next: MoveOption<K>,
+    pub(crate) value: V,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
@@ -369,6 +485,31 @@ pub struct DagEdge {
     pub from: DagOutputVariantPort,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct DagEdgeBcs {
+    pub(crate) from: DagOutputVariantPort,
+    #[allow(dead_code)]
+    pub(crate) to: DagVertexInputPort,
+    #[allow(dead_code)]
+    pub(crate) kind: DagEdgeKindBcs,
+}
+
+impl DagEdgeBcs {
+    pub(crate) fn into_sdk(self) -> DagEdge {
+        DagEdge { from: self.from }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum DagEdgeKindBcs {
+    Normal,
+    ForEach,
+    Collect,
+    DoWhile,
+    Break,
+    Static,
+}
+
 /// Struct holding the output variant and port pair.
 ///
 /// See <sui/workflow/sources/dag.move:OutputVariantPort> for documentation.
@@ -410,6 +551,58 @@ mod tests {
         let json = serde_json::to_string(&kind).unwrap();
         let deserialized: DagVertexKind = serde_json::from_str(&json).unwrap();
         assert_eq!(kind.tool_fqn(), deserialized.tool_fqn());
+    }
+
+    #[test]
+    fn test_dag_vertex_info_bcs_converts_linked_table_node() {
+        let value = LinkedTableNodeBcs {
+            prev: MoveOption(None::<TypeName>),
+            next: MoveOption(None::<TypeName>),
+            value: DagVertexInfoBcs {
+                kind: DagVertexKindBcs::OnChain {
+                    _variant_name: "OnChain".to_string(),
+                    tool_fqn: "demo.taluslabs.demo_onchain_vertex@1".to_string(),
+                },
+                input_ports: MoveVecSet {
+                    contents: vec![
+                        DagInputPort {
+                            name: "prompt".to_string(),
+                        },
+                        DagInputPort {
+                            name: "recipient".to_string(),
+                        },
+                    ],
+                },
+                post_failure_action: MoveOption(None),
+                leader_verifier: MoveOption(None),
+                tool_verifier: MoveOption(Some(VerifierConfigBcs {
+                    mode: VerifierModeBcs::ToolVerifierContract,
+                    method: "demo_verifier_v1".to_string(),
+                })),
+            },
+        };
+
+        let encoded = bcs::to_bytes(&value).unwrap();
+        let decoded: LinkedTableNodeBcs<TypeName, DagVertexInfoBcs> =
+            bcs::from_bytes(&encoded).unwrap();
+        let vertex = decoded.value.into_sdk().unwrap();
+
+        assert!(matches!(vertex.kind, DagVertexKind::OnChain { .. }));
+        assert_eq!(
+            vertex.kind.tool_fqn().to_string(),
+            "demo.taluslabs.demo_onchain_vertex@1"
+        );
+        assert_eq!(
+            vertex.declared_input_port_names(),
+            vec!["prompt".to_string(), "recipient".to_string()]
+        );
+        assert_eq!(
+            vertex.tool_verifier,
+            Some(VerifierConfig {
+                mode: VerifierMode::ToolVerifierContract,
+                method: "demo_verifier_v1".to_string(),
+            })
+        );
     }
 
     #[test]

--- a/sdk/src/nexus/workflow.rs
+++ b/sdk/src/nexus/workflow.rs
@@ -19,7 +19,17 @@ use {
             client::NexusClient,
             crawler::{Crawler, Response},
             error::NexusError,
-            models::{Dag, DagExecution, DagVertexInfo},
+            models::{
+                Dag,
+                DagEdge,
+                DagEdgeBcs,
+                DagExecution,
+                DagOutputVariantPort,
+                DagVertexInfo,
+                DagVertexInfoBcs,
+                DagVertexInputPort,
+                LinkedTableNodeBcs,
+            },
             tap,
         },
         sui,
@@ -268,13 +278,75 @@ pub fn dag_vertex_requires_verifier_proof(dag: &Dag, vertex: &DagVertexInfo) -> 
     )
 }
 
+pub async fn fetch_dag_vertices_bcs(
+    crawler: &Crawler,
+    dag: &Dag,
+) -> anyhow::Result<HashMap<crate::types::TypeName, DagVertexInfo>> {
+    crawler
+        .get_dynamic_fields_bcs::<
+            crate::types::TypeName,
+            LinkedTableNodeBcs<crate::types::TypeName, DagVertexInfoBcs>,
+        >(dag.vertices.id(), dag.vertices.size())
+        .await?
+        .into_iter()
+        .map(|(vertex, node)| Ok((vertex, node.value.into_sdk()?)))
+        .collect()
+}
+
+pub async fn fetch_dag_default_values_bcs<T>(
+    crawler: &Crawler,
+    dag: &Dag,
+) -> anyhow::Result<HashMap<DagVertexInputPort, T>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    crawler
+        .get_dynamic_fields_bcs::<DagVertexInputPort, T>(
+            dag.defaults_to_input_ports.id(),
+            dag.defaults_to_input_ports.size(),
+        )
+        .await
+}
+
+pub async fn fetch_dag_edges_bcs(
+    crawler: &Crawler,
+    dag: &Dag,
+) -> anyhow::Result<HashMap<crate::types::TypeName, Vec<DagEdge>>> {
+    crawler
+        .get_dynamic_fields_bcs::<crate::types::TypeName, Vec<DagEdgeBcs>>(
+            dag.edges.id(),
+            dag.edges.size(),
+        )
+        .await?
+        .into_iter()
+        .map(|(vertex, edges)| {
+            Ok((
+                vertex,
+                edges.into_iter().map(DagEdgeBcs::into_sdk).collect(),
+            ))
+        })
+        .collect()
+}
+
+pub async fn fetch_dag_outputs_bcs(
+    crawler: &Crawler,
+    dag: &Dag,
+) -> anyhow::Result<HashMap<crate::types::TypeName, Vec<DagOutputVariantPort>>> {
+    crawler
+        .get_dynamic_fields_bcs::<crate::types::TypeName, Vec<DagOutputVariantPort>>(
+            dag.outputs.id(),
+            dag.outputs.size(),
+        )
+        .await
+}
+
 pub async fn offchain_success_requires_verifier_proof(
     crawler: &Crawler,
     dag_object_id: sui::types::Address,
     next_vertex: &RuntimeVertex,
 ) -> anyhow::Result<bool> {
     let dag = crawler.get_object::<Dag>(dag_object_id).await?;
-    let mut vertices = crawler.get_dynamic_fields(&dag.data.vertices).await?;
+    let mut vertices = fetch_dag_vertices_bcs(crawler, &dag.data).await?;
     let vertex_name = next_vertex.name();
     let vertex = vertices
         .remove(&vertex_name)
@@ -288,7 +360,7 @@ pub async fn fetch_vertex_input_port_names(
     dag: &Dag,
     vertex_name: &crate::types::TypeName,
 ) -> anyhow::Result<Vec<String>> {
-    let mut vertices = crawler.get_dynamic_fields(&dag.vertices).await?;
+    let mut vertices = fetch_dag_vertices_bcs(crawler, dag).await?;
     let vertex = vertices.remove(vertex_name).ok_or_else(|| {
         anyhow!("Vertex '{vertex_name}' not found in DAG vertices dynamic fields")
     })?;
@@ -2502,5 +2574,27 @@ mod tests {
             vertex.declared_input_port_names(),
             vec!["a_port".to_string(), "z_port".to_string()]
         );
+    }
+
+    #[test]
+    fn dag_edge_bcs_into_sdk_keeps_the_public_edge_shape() {
+        let edge = DagEdgeBcs {
+            from: DagOutputVariantPort {
+                variant: crate::types::TypeName::from("ok"),
+                port: crate::types::TypeName::from("value"),
+            },
+            to: DagVertexInputPort {
+                vertex: crate::types::TypeName::from("next"),
+                port: crate::nexus::models::DagInputPort {
+                    name: "input".to_string(),
+                },
+            },
+            kind: crate::nexus::models::DagEdgeKindBcs::Static,
+        };
+
+        let sdk = edge.into_sdk();
+
+        assert_eq!(sdk.from.variant, crate::types::TypeName::from("ok"));
+        assert_eq!(sdk.from.port, crate::types::TypeName::from("value"));
     }
 }

--- a/sdk/src/transactions/dag.rs
+++ b/sdk/src/transactions/dag.rs
@@ -1518,14 +1518,10 @@ pub fn mint_vertex_authorization_check_cap_for_onchain_walk(
     objects: &NexusObjects,
     dag: sui::types::Argument,
     execution: sui::types::Argument,
-    request_walk_execution: sui::types::Argument,
     leader_cap: sui::types::Argument,
     walk_index: u64,
-    expected_vertex: &RuntimeVertex,
 ) -> anyhow::Result<sui::types::Argument> {
     let walk_index = tx.input(pure_arg(&walk_index)?);
-    let expected_vertex =
-        workflow::Dag::runtime_vertex_from_enum(tx, objects.workflow_pkg_id, expected_vertex)?;
     Ok(tx.move_call(
         sui::tx::Function::new(
             objects.workflow_pkg_id,
@@ -1533,14 +1529,7 @@ pub fn mint_vertex_authorization_check_cap_for_onchain_walk(
             workflow::Dag::MINT_VERTEX_AUTHORIZATION_CHECK_CAP_FOR_ONCHAIN_WALK.name,
             vec![],
         ),
-        vec![
-            dag,
-            execution,
-            request_walk_execution,
-            leader_cap,
-            walk_index,
-            expected_vertex,
-        ],
+        vec![dag, execution, leader_cap, walk_index],
     ))
 }
 
@@ -3322,6 +3311,39 @@ mod tests {
             objects.workflow_pkg_id,
             witness,
         );
+    }
+
+    #[test]
+    fn test_mint_vertex_authorization_check_cap_for_onchain_walk_uses_active_walk_args() {
+        let objects = sui_mocks::mock_nexus_objects();
+        let mut tx = sui::tx::TransactionBuilder::new();
+        let dag = sui::types::Argument::Result(0);
+        let execution = sui::types::Argument::Result(1);
+        let leader_cap = sui::types::Argument::Result(2);
+
+        mint_vertex_authorization_check_cap_for_onchain_walk(
+            &mut tx, &objects, dag, execution, leader_cap, 17,
+        )
+        .expect("mint helper should build");
+
+        let inspector = TxInspector::new(sui_mocks::mock_finish_transaction(tx));
+        let call = inspector.move_call(inspector.commands().len() - 1);
+
+        assert_eq!(call.package, objects.workflow_pkg_id);
+        assert_eq!(
+            call.module,
+            workflow::Dag::MINT_VERTEX_AUTHORIZATION_CHECK_CAP_FOR_ONCHAIN_WALK.module
+        );
+        assert_eq!(
+            call.function,
+            workflow::Dag::MINT_VERTEX_AUTHORIZATION_CHECK_CAP_FOR_ONCHAIN_WALK.name
+        );
+        assert_eq!(call.arguments.len(), 4);
+        assert_eq!(call.arguments[0], dag);
+        assert_eq!(call.arguments[1], execution);
+        assert_eq!(call.arguments[2], leader_cap);
+        inspector.expect_u64(&call.arguments[3], 17);
+        assert_eq!(inspector.inputs().len(), 1);
     }
 
     fn assert_on_chain_submit_call_uses_sdk_move_values(

--- a/sdk/src/types/tap.rs
+++ b/sdk/src/types/tap.rs
@@ -1414,7 +1414,7 @@ pub struct WorkflowVertexAuthorizationGrant {
     #[serde(deserialize_with = "deserialize_tap_address_value")]
     pub id: sui::types::Address,
     #[serde(deserialize_with = "deserialize_tap_address_value")]
-    pub walk_execution_id: sui::types::Address,
+    pub execution_id: sui::types::Address,
     #[serde(deserialize_with = "deserialize_tap_runtime_vertex")]
     pub vertex: RuntimeVertex,
 }
@@ -2868,13 +2868,13 @@ mod tests {
     fn workflow_vertex_authorization_grant_model_matches_live_object_shape() {
         let grant: WorkflowVertexAuthorizationGrant = serde_json::from_value(serde_json::json!({
             "id": "0xaa",
-            "walk_execution_id": "0xff",
+            "execution_id": "0xff",
             "vertex": [101, 110, 116, 114, 121]
         }))
         .expect("grant should deserialize");
 
         assert_eq!(grant.id, addr("0xaa"));
-        assert_eq!(grant.walk_execution_id, addr("0xff"));
+        assert_eq!(grant.execution_id, addr("0xff"));
         assert_eq!(grant.vertex, RuntimeVertex::plain("entry"));
     }
 


### PR DESCRIPTION
## Notable changes

- `PaymentLockUpdateEvent` parsing is now allowed from public workflow/TAP calls emitted through non-Nexus caller packages, with regression coverage for the wrapped event shape used by cap-gated standard TAP executions.
- SDK models now expose scheduled TAP task and occurrence context from `DAGExecution`, so execution inspection and payment recovery can identify the scheduled task that funded a walk.
- `ExecutionCostResult` now reports the standard TAP payment object, locked budget, consumed amount, outstanding vertex locks, and terminal accomplishment/refund status from execution-owned payment state.
- PTB helpers now cover vertex authorization grant creation and active-walk authorization-check-cap minting for cap-gated on-chain tools.
- Workflow object decoding now treats the standard TAP execution context as complete only when agent, skill, endpoint revision, payment, selected DAG, authorization plan, and scheduled occurrence fields are consistent.
- `VertexAuthorizationGrantCreatedEvent` and `WorkflowVertexAuthorizationGrant` now use `execution_id`, matching the current Move object/event layout.
- Default DAG execution helpers prefer the configured `default_tap_target` when it resolves to a runtime-selected active skill, then fall back to registry recovery.

## References

used in Nexus and workbench

## Checklist

- [x ] keep a changelog
- [x ] write tests
- [ ] create tickets for `TODO: <>` statements
- [ ] create or update documentation
