### PR TITLE
feat: implement priority fee

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -10,4 +10,4 @@ fo = "fo" # this "fo" thing appears a lot in IDs, like "b26v89c19zqg8o3fo7dpmyo3
 PN = "PN" # used in sdk/src/crypto
 
 [files]
-extend-exclude = ["sdk/src/idents/generated/ir/*.json"]
+extend-exclude = ["sdk/src/move_bindings/ir/*.json"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Move binding regeneration now accepts an optional matching Move source root for restoring
   function parameter names. Network package metadata remains authoritative, and regeneration
   without source keeps deterministic `argN` names.
+- Added support for new priority fee system.
 
 #### Changed
 
@@ -20,6 +21,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   limiting deployment refreshes to Nexus packages.
 - Move binding regeneration now commits canonical SDK package identities, preventing package ID
   churn when the same Move ABI is rebound from another deployment.
+
+### `nexus-cli`
+
+#### Added
+
+- Added support for new priority fee system in commands.
 
 ## [`2.0.0-rc.4`] - 2026-07-09
 

--- a/cli/src/dag/dag_execute.rs
+++ b/cli/src/dag/dag_execute.rs
@@ -16,6 +16,20 @@ use {
     },
 };
 
+fn agent_dag_execute_options_from_cli_budget(
+    owner: sui::types::Address,
+    payment_coin: sui::types::ObjectReference,
+    payment_coin_balance: u64,
+    payment_max_budget_mist: u64,
+) -> AnyResult<AgentDagExecuteOptions, NexusCliError> {
+    Ok(AgentDagExecuteOptions {
+        payment_source: payment_source_from_address(owner).map_err(NexusCliError::Any)?,
+        payment_coin: Some(payment_coin),
+        payment_coin_balance: Some(payment_coin_balance),
+        payment_max_budget_mist,
+    })
+}
+
 /// Execute a Nexus DAG based on the provided object ID and initial input data.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_dag(
@@ -24,9 +38,9 @@ pub(crate) async fn execute_dag(
     input_json: serde_json::Value,
     remote: Vec<String>,
     inspect: bool,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: u64,
     payment_coin: Option<sui::types::Address>,
-    payment_budget: Option<u64>,
+    payment_max_budget_mist: Option<u64>,
     sui_gas_coin: Option<sui::types::Address>,
     sui_gas_budget: u64,
 ) -> AnyResult<(), NexusCliError> {
@@ -64,10 +78,10 @@ pub(crate) async fn execute_dag(
     }
     let (payment_coin, balance) =
         fetch_coin_with_balance(client.clone(), owner, Some(payment_coin_id), 0).await?;
-    let budget = payment_budget.unwrap_or(balance);
-    if budget > balance {
+    let payment_max_budget_mist = payment_max_budget_mist.unwrap_or(balance);
+    if payment_max_budget_mist > balance {
         return Err(NexusCliError::Any(anyhow!(
-            "payment budget {budget} exceeds payment coin balance {balance}"
+            "payment maximum budget {payment_max_budget_mist} MIST exceeds payment coin balance {balance} MIST"
         )));
     }
 
@@ -80,12 +94,12 @@ pub(crate) async fn execute_dag(
     // Store ports remote if they need to be stored remotely.
     let input_data =
         workflow::process_entry_ports(&input_json, preferred_remote_storage, &remote).await?;
-    let agent_dag_options = AgentDagExecuteOptions {
-        payment_source: payment_source_from_address(owner).map_err(NexusCliError::Any)?,
-        payment_coin: Some(payment_coin),
-        payment_coin_balance: Some(balance),
-        payment_max_budget: budget,
-    };
+    let agent_dag_options = agent_dag_execute_options_from_cli_budget(
+        owner,
+        payment_coin,
+        balance,
+        payment_max_budget_mist,
+    )?;
 
     let tx_handle = loading!("Crafting and executing transaction...");
 
@@ -94,7 +108,7 @@ pub(crate) async fn execute_dag(
         .execute_default_agent_dag(
             dag_id,
             input_data,
-            priority_fee_per_gas_unit,
+            Some(priority_fee_percentage),
             Some(&entry_group),
             &storage_conf,
             agent_dag_options,
@@ -145,4 +159,23 @@ pub(crate) async fn execute_dag(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, nexus_sdk::test_utils::sui_mocks};
+
+    #[test]
+    fn dag_execute_payment_budget_is_total_escrow() {
+        let owner = sui::types::Address::from_static("0xa11ce");
+        let payment_coin = sui_mocks::mock_sui_object_ref();
+
+        let options =
+            agent_dag_execute_options_from_cli_budget(owner, payment_coin.clone(), 1_000, 120)
+                .expect("CLI options should build");
+
+        assert_eq!(options.payment_coin, Some(payment_coin));
+        assert_eq!(options.payment_coin_balance, Some(1_000));
+        assert_eq!(options.payment_max_budget_mist, 120);
+    }
 }

--- a/cli/src/dag/dag_execution_cost.rs
+++ b/cli/src/dag/dag_execution_cost.rs
@@ -50,12 +50,12 @@ pub(crate) async fn execution_cost(
         "Budget: {} locked from max {}",
         format!(
             "{} MIST",
-            result.locked_budget.to_formatted_string(&Locale::en)
+            result.locked_budget_mist.to_formatted_string(&Locale::en)
         )
         .truecolor(100, 100, 100),
         format!(
             "{} MIST",
-            result.max_budget.to_formatted_string(&Locale::en)
+            result.max_budget_mist.to_formatted_string(&Locale::en)
         )
         .truecolor(100, 100, 100)
     );
@@ -69,8 +69,8 @@ pub(crate) async fn execution_cost(
 
     json_output(&serde_json::json!({
         "payment_id": result.payment_id,
-        "max_budget": result.max_budget,
-        "locked_budget": result.locked_budget,
+        "max_budget_mist": result.max_budget_mist,
+        "locked_budget_mist": result.locked_budget_mist,
         "consumed": result.consumed,
         "outstanding_locks": result.outstanding_locks,
         "accomplished": result.accomplished,

--- a/cli/src/dag/mod.rs
+++ b/cli/src/dag/mod.rs
@@ -92,14 +92,13 @@ pub(crate) enum DagCommand {
             help = "Whether to inspect the DAG execution process. If not provided, command returns after submitting the transaction."
         )]
         inspect: bool,
-        /// Priority fee per gas unit for the DAG execution.
+        /// Priority fee percentage for the DAG execution.
         #[arg(
-            long = "priority-fee-per-gas-unit",
-            help = "Priority fee per gas unit to pass to the DAG execution. Defaults to 0 when omitted.",
-            value_name = "AMOUNT",
-            default_value_t = 0u64
+            long = "priority-fee-percentage",
+            help = "Optional priority fee percentage to pass to the DAG execution.",
+            value_name = "PERCENTAGE"
         )]
-        priority_fee_per_gas_unit: u64,
+        priority_fee_percentage: Option<u64>,
         #[arg(
             long = "payment-coin",
             help = "SUI coin object ID to lock as the standard TAP execution payment.",
@@ -107,11 +106,11 @@ pub(crate) enum DagCommand {
         )]
         payment_coin: Option<sui::types::Address>,
         #[arg(
-            long = "payment-budget",
-            help = "Optional payment budget in MIST. Defaults to the full payment coin balance.",
-            value_name = "AMOUNT"
+            long = "payment-max-budget-mist",
+            help = "Optional maximum payment budget in MIST, including gas and priority fee. Defaults to the full payment coin balance.",
+            value_name = "MIST"
         )]
-        payment_budget: Option<u64>,
+        payment_max_budget_mist: Option<u64>,
         #[command(flatten)]
         gas: GasArgs,
     },
@@ -181,9 +180,9 @@ pub(crate) async fn handle(command: DagCommand) -> AnyResult<(), NexusCliError> 
             input_json,
             remote,
             inspect,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             payment_coin,
-            payment_budget,
+            payment_max_budget_mist,
             gas,
         } => {
             // Optional: Check auth at CLI level instead of inside execute_dag
@@ -195,9 +194,9 @@ pub(crate) async fn handle(command: DagCommand) -> AnyResult<(), NexusCliError> 
                 input_json,
                 remote,
                 inspect,
-                priority_fee_per_gas_unit,
+                priority_fee_percentage.unwrap_or(20),
                 payment_coin,
-                payment_budget,
+                payment_max_budget_mist,
                 gas.sui_gas_coin,
                 gas.sui_gas_budget,
             )

--- a/cli/src/scheduler/occurrence/mod.rs
+++ b/cli/src/scheduler/occurrence/mod.rs
@@ -32,13 +32,9 @@ pub(crate) enum OccurrenceCommand {
         start: OccurrenceStartOptions,
         #[command(flatten)]
         deadline: OccurrenceDeadlineOptions,
-        /// Priority fee per gas unit applied to the occurrence.
-        #[arg(
-            long = "priority-fee-per-gas-unit",
-            value_name = "AMOUNT",
-            default_value_t = 0u64
-        )]
-        priority_fee_per_gas_unit: u64,
+        /// Optional priority fee percentage applied to the occurrence.
+        #[arg(long = "priority-fee-percentage", value_name = "PERCENTAGE")]
+        priority_fee_percentage: Option<u64>,
         #[command(flatten)]
         gas: GasArgs,
     },
@@ -50,7 +46,7 @@ pub(crate) async fn handle(command: OccurrenceCommand) -> AnyResult<(), NexusCli
             task_id,
             start,
             deadline,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             gas,
         } => {
             let OccurrenceStartOptions {
@@ -64,7 +60,7 @@ pub(crate) async fn handle(command: OccurrenceCommand) -> AnyResult<(), NexusCli
                 start_ms,
                 start_offset_ms,
                 deadline_offset_ms,
-                priority_fee_per_gas_unit,
+                priority_fee_percentage,
                 gas,
             )
             .await

--- a/cli/src/scheduler/occurrence/occurrence_add.rs
+++ b/cli/src/scheduler/occurrence/occurrence_add.rs
@@ -16,7 +16,7 @@ pub(crate) async fn add_occurrence_to_task(
     start_ms: Option<u64>,
     start_offset_ms: Option<u64>,
     deadline_offset_ms: Option<u64>,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     gas: GasArgs,
 ) -> AnyResult<(), NexusCliError> {
     command_title!(
@@ -29,7 +29,7 @@ pub(crate) async fn add_occurrence_to_task(
         None,
         start_offset_ms,
         deadline_offset_ms,
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
         true,
     )
     .map_err(NexusCliError::Nexus)?;
@@ -50,7 +50,7 @@ pub(crate) async fn add_occurrence_to_task(
         "start_ms": start_ms,
         "start_offset_ms": start_offset_ms,
         "deadline_offset_ms": deadline_offset_ms,
-        "priority_fee_per_gas_unit": priority_fee_per_gas_unit,
+        "priority_fee_percentage": priority_fee_percentage,
     }))?;
 
     Ok(())

--- a/cli/src/scheduler/periodic/mod.rs
+++ b/cli/src/scheduler/periodic/mod.rs
@@ -22,13 +22,9 @@ pub(crate) enum PeriodicCommand {
         /// Maximum number of generated occurrences (None for infinite).
         #[arg(long = "max-iterations", value_name = "COUNT")]
         max_iterations: Option<u64>,
-        /// Priority fee per gas unit associated with occurrences.
-        #[arg(
-            long = "priority-fee-per-gas-unit",
-            value_name = "AMOUNT",
-            default_value_t = 0u64
-        )]
-        priority_fee_per_gas_unit: u64,
+        /// Optional priority fee percentage associated with occurrences.
+        #[arg(long = "priority-fee-percentage", value_name = "PERCENTAGE")]
+        priority_fee_percentage: Option<u64>,
         #[command(flatten)]
         gas: GasArgs,
     },
@@ -50,7 +46,7 @@ pub(crate) async fn handle(command: PeriodicCommand) -> AnyResult<(), NexusCliEr
             period_ms,
             deadline_offset_ms,
             max_iterations,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             gas,
         } => {
             periodic_set::set_periodic_task(
@@ -59,7 +55,7 @@ pub(crate) async fn handle(command: PeriodicCommand) -> AnyResult<(), NexusCliEr
                 period_ms,
                 deadline_offset_ms,
                 max_iterations,
-                priority_fee_per_gas_unit,
+                priority_fee_percentage,
                 gas,
             )
             .await

--- a/cli/src/scheduler/periodic/periodic_set.rs
+++ b/cli/src/scheduler/periodic/periodic_set.rs
@@ -17,7 +17,7 @@ pub(crate) async fn set_periodic_task(
     period_ms: u64,
     deadline_offset_ms: Option<u64>,
     max_iterations: Option<u64>,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     gas: GasArgs,
 ) -> AnyResult<(), NexusCliError> {
     command_title!(
@@ -36,7 +36,7 @@ pub(crate) async fn set_periodic_task(
                 period_ms,
                 deadline_offset_ms,
                 max_iterations,
-                priority_fee_per_gas_unit,
+                priority_fee_percentage,
             },
         )
         .await
@@ -50,7 +50,7 @@ pub(crate) async fn set_periodic_task(
         "period_ms": period_ms,
         "deadline_offset_ms": deadline_offset_ms,
         "max_iterations": max_iterations,
-        "priority_fee_per_gas_unit": priority_fee_per_gas_unit,
+        "priority_fee_percentage": priority_fee_percentage,
     }))?;
 
     Ok(())

--- a/cli/src/scheduler/task/mod.rs
+++ b/cli/src/scheduler/task/mod.rs
@@ -78,24 +78,16 @@ pub(crate) enum TaskCommand {
         /// Metadata entries to attach to the task as key=value pairs.
         #[arg(long = "metadata", short = 'm', value_name = "KEY=VALUE")]
         metadata: Vec<String>,
-        /// Priority fee per gas unit for DAG executions launched by the task.
-        #[arg(
-            long = "execution-priority-fee-per-gas-unit",
-            value_name = "AMOUNT",
-            default_value_t = 0u64
-        )]
-        execution_priority_fee_per_gas_unit: u64,
+        /// Optional priority fee percentage for DAG executions launched by the task.
+        #[arg(long = "execution-priority-fee-percentage", value_name = "PERCENTAGE")]
+        execution_priority_fee_percentage: Option<u64>,
         #[command(flatten)]
         schedule_start: ScheduleStartOptions,
         #[command(flatten)]
         schedule_deadline: ScheduleDeadlineOptions,
-        /// Priority fee per gas unit for the initial occurrence.
-        #[arg(
-            long = "schedule-priority-fee-per-gas-unit",
-            value_name = "AMOUNT",
-            default_value_t = 0u64
-        )]
-        schedule_priority_fee_per_gas_unit: u64,
+        /// Optional priority fee percentage for the initial occurrence.
+        #[arg(long = "schedule-priority-fee-percentage", value_name = "PERCENTAGE")]
+        schedule_priority_fee_percentage: Option<u64>,
         /// Generator responsible for producing future occurrences for this task.
         #[arg(
             long = "generator",
@@ -105,11 +97,11 @@ pub(crate) enum TaskCommand {
         )]
         generator: TaskGeneratorArg,
         /// Amount of SUI, in MIST, to reserve for default-agent scheduled execution payments.
-        #[arg(long = "prepay-amount", value_name = "AMOUNT")]
-        prepay_amount: u64,
+        #[arg(long = "prepay-amount-mist", value_name = "MIST")]
+        prepay_amount_mist: u64,
         /// Maximum SUI, in MIST, that each occurrence may spend from the payment reserve.
-        #[arg(long = "occurrence-budget", value_name = "AMOUNT")]
-        occurrence_budget: u64,
+        #[arg(long = "occurrence-budget-mist", value_name = "MIST")]
+        occurrence_budget_mist: u64,
         #[command(flatten)]
         gas: GasArgs,
     },
@@ -169,13 +161,13 @@ pub(crate) async fn handle(command: TaskCommand) -> AnyResult<(), NexusCliError>
             input_json,
             remote,
             metadata,
-            execution_priority_fee_per_gas_unit,
+            execution_priority_fee_percentage,
             schedule_start,
             schedule_deadline,
-            schedule_priority_fee_per_gas_unit,
+            schedule_priority_fee_percentage,
             generator,
-            prepay_amount,
-            occurrence_budget,
+            prepay_amount_mist,
+            occurrence_budget_mist,
             gas,
         } => {
             let ScheduleStartOptions {
@@ -192,14 +184,14 @@ pub(crate) async fn handle(command: TaskCommand) -> AnyResult<(), NexusCliError>
                 input_json,
                 remote,
                 metadata,
-                execution_priority_fee_per_gas_unit,
+                execution_priority_fee_percentage,
                 schedule_start_ms,
                 schedule_start_offset_ms,
                 schedule_deadline_offset_ms,
-                schedule_priority_fee_per_gas_unit,
+                schedule_priority_fee_percentage,
                 generator.into(),
-                prepay_amount,
-                occurrence_budget,
+                prepay_amount_mist,
+                occurrence_budget_mist,
                 gas,
             )
             .await

--- a/cli/src/scheduler/task/task_create.rs
+++ b/cli/src/scheduler/task/task_create.rs
@@ -31,14 +31,14 @@ pub(crate) async fn create_task(
     mut input_json: Option<serde_json::Value>,
     remote: Vec<String>,
     metadata: Vec<String>,
-    execution_priority_fee_per_gas_unit: u64,
+    execution_priority_fee_percentage: Option<u64>,
     schedule_start_ms: Option<u64>,
     schedule_start_offset_ms: Option<u64>,
     schedule_deadline_offset_ms: Option<u64>,
-    schedule_priority_fee_per_gas_unit: u64,
+    schedule_priority_fee_percentage: Option<u64>,
     generator: GeneratorKind,
-    prepay_amount: u64,
-    occurrence_budget: u64,
+    prepay_amount_mist: u64,
+    occurrence_budget_mist: u64,
     gas: GasArgs,
 ) -> AnyResult<(), NexusCliError> {
     command_title!(
@@ -89,7 +89,7 @@ pub(crate) async fn create_task(
                 None,
                 schedule_start_offset_ms,
                 schedule_deadline_offset_ms,
-                schedule_priority_fee_per_gas_unit,
+                schedule_priority_fee_percentage,
                 true,
             )
             .map_err(NexusCliError::Nexus)?,
@@ -113,15 +113,15 @@ pub(crate) async fn create_task(
             entry_group: entry_group.clone(),
             input_data,
             metadata: metadata_pairs,
-            execution_priority_fee_per_gas_unit,
+            execution_priority_fee_percentage,
             initial_schedule,
             generator,
             agent_id: None,
             skill_id: None,
             tap_payment: Some(CreateTaskTapPayment::UserFunded {
-                prepay_amount,
+                prepay_amount_mist,
                 refund_recipient: None,
-                occurrence_budget,
+                occurrence_budget_mist,
                 selected_dag: None,
                 authorization_templates: Vec::new(),
             }),
@@ -149,8 +149,8 @@ pub(crate) async fn create_task(
         result_json["tap_payment"] = serde_json::json!({
             "agent_id": tap_payment.agent_id,
             "skill_id": tap_payment.skill_id,
-            "prepay_amount": tap_payment.prepay_amount,
-            "occurrence_budget": tap_payment.occurrence_budget,
+            "prepay_amount_mist": tap_payment.prepay_amount_mist,
+            "occurrence_budget_mist": tap_payment.occurrence_budget_mist,
         });
     }
 

--- a/cli/src/sui.rs
+++ b/cli/src/sui.rs
@@ -373,6 +373,11 @@ mod tests {
                 version = 1
                 digest = "3LFAfxPb6Q81U8wXg6qc6UyV9Hoj1VdfFfMwvGTEq5Bv"
 
+                [priority_fee_vault]
+                object_id = "0x14"
+                version = 1
+                digest = "3LFAfxPb6Q81U8wXg6qc6UyV9Hoj1VdfFfMwvGTEq5Bv"
+
                 [verifier_registry]
                 object_id = "0x12"
                 version = 1
@@ -450,6 +455,11 @@ mod tests {
             *objects.leader_registry.digest(),
             sui::types::Digest::from_static("3LFAfxPb6Q81U8wXg6qc6UyV9Hoj1VdfFfMwvGTEq5Bv")
         );
+        assert_eq!(
+            *objects.priority_fee_vault.object_id(),
+            sui::types::Address::from_static("0x14")
+        );
+        assert_eq!(objects.priority_fee_vault.version(), 1);
         assert_eq!(
             *objects.verifier_registry.object_id(),
             sui::types::Address::from_static("0x12")

--- a/cli/src/tap/mod.rs
+++ b/cli/src/tap/mod.rs
@@ -178,11 +178,11 @@ pub(crate) enum TapCommand {
         )]
         payment_mode: ArtifactPaymentMode,
         #[arg(
-            long = "agent-funded-max-budget",
-            help = "Maximum budget for agent-funded skills.",
-            value_name = "AMOUNT"
+            long = "agent-funded-max-budget-mist",
+            help = "Maximum budget in MIST for agent-funded skills.",
+            value_name = "MIST"
         )]
-        agent_funded_max_budget: Option<u64>,
+        agent_funded_max_budget_mist: Option<u64>,
         #[arg(long, default_value = "once", help = "Schedule recurrence kind.")]
         recurrence_kind: String,
         #[arg(long, default_value_t = 0, help = "Minimum interval in milliseconds.")]
@@ -311,12 +311,11 @@ pub(crate) enum TapCommand {
         )]
         remote: Vec<String>,
         #[arg(
-            long = "priority-fee-per-gas-unit",
-            help = "Priority fee per gas unit for the DAG execution. Defaults to 0 when omitted.",
-            value_name = "AMOUNT",
-            default_value_t = 0u64
+            long = "priority-fee-percentage",
+            help = "Optional priority fee percentage for the DAG execution.",
+            value_name = "PERCENTAGE"
         )]
-        priority_fee_per_gas_unit: u64,
+        priority_fee_percentage: Option<u64>,
         #[arg(
             long = "payment-source-hex",
             help = "Payment source bytes as hex.",
@@ -325,12 +324,12 @@ pub(crate) enum TapCommand {
         )]
         payment_source_hex: String,
         #[arg(
-            long = "payment-max-budget",
-            help = "Maximum standard TAP payment budget.",
-            value_name = "AMOUNT",
+            long = "payment-max-budget-mist",
+            help = "Maximum standard TAP payment budget in MIST, including gas and priority fee.",
+            value_name = "MIST",
             default_value_t = 0u64
         )]
-        payment_max_budget: u64,
+        payment_max_budget_mist: u64,
         #[command(flatten)]
         gas: GasArgs,
     },
@@ -372,22 +371,14 @@ pub(crate) enum TapCommand {
         remote: Vec<String>,
         #[arg(long = "metadata", short = 'm', value_name = "KEY=VALUE")]
         metadata: Vec<String>,
-        #[arg(
-            long = "execution-priority-fee-per-gas-unit",
-            value_name = "AMOUNT",
-            default_value_t = 0u64
-        )]
-        execution_priority_fee_per_gas_unit: u64,
+        #[arg(long = "execution-priority-fee-percentage", value_name = "PERCENTAGE")]
+        execution_priority_fee_percentage: Option<u64>,
         #[command(flatten)]
         schedule_start: crate::scheduler::task::ScheduleStartOptions,
         #[command(flatten)]
         schedule_deadline: crate::scheduler::task::ScheduleDeadlineOptions,
-        #[arg(
-            long = "schedule-priority-fee-per-gas-unit",
-            value_name = "AMOUNT",
-            default_value_t = 0u64
-        )]
-        schedule_priority_fee_per_gas_unit: u64,
+        #[arg(long = "schedule-priority-fee-percentage", value_name = "PERCENTAGE")]
+        schedule_priority_fee_percentage: Option<u64>,
         #[arg(
             long = "generator",
             value_enum,
@@ -397,12 +388,12 @@ pub(crate) enum TapCommand {
         generator: crate::scheduler::task::TaskGeneratorArg,
         #[arg(long = "payment-source", value_enum, value_name = "SOURCE")]
         payment_source: TapTaskPaymentSourceArg,
-        #[arg(long = "prepay-amount", value_name = "AMOUNT")]
-        prepay_amount: u64,
+        #[arg(long = "prepay-amount-mist", value_name = "MIST")]
+        prepay_amount_mist: u64,
         #[arg(long = "refund-recipient", value_name = "ADDRESS")]
         refund_recipient: Option<sui::types::Address>,
-        #[arg(long = "occurrence-budget", value_name = "AMOUNT")]
-        occurrence_budget: u64,
+        #[arg(long = "occurrence-budget-mist", value_name = "MIST")]
+        occurrence_budget_mist: u64,
         #[command(flatten)]
         gas: GasArgs,
     },
@@ -569,7 +560,7 @@ pub(crate) enum PaymentsCommand {
         all: bool,
     },
     #[command(
-        about = "Resolve a standard TAP payment by returning funds to the invoker given the execution is finished. Routes through `accomplish_tap_execution_payment_from_agent_vault` when `--alias`/`--agent-id` is supplied, otherwise calls `accomplish_tap_execution_payment`."
+        about = "Resolve a standard TAP payment. Routes through the agent-vault settlement when `--alias`/`--agent-id` is supplied."
     )]
     Resolve {
         #[arg(
@@ -684,7 +675,7 @@ pub(crate) async fn handle(command: TapCommand) -> AnyResult<(), NexusCliError> 
             dag_id,
             interface_revision,
             payment_mode,
-            agent_funded_max_budget,
+            agent_funded_max_budget_mist,
             recurrence_kind,
             min_interval_ms,
             max_occurrences,
@@ -697,7 +688,7 @@ pub(crate) async fn handle(command: TapCommand) -> AnyResult<(), NexusCliError> 
                 dag_id,
                 interface_revision,
                 payment_mode,
-                agent_funded_max_budget,
+                agent_funded_max_budget_mist,
                 recurrence_kind,
                 min_interval_ms,
                 max_occurrences,
@@ -747,9 +738,9 @@ pub(crate) async fn handle(command: TapCommand) -> AnyResult<(), NexusCliError> 
             entry_group,
             input_json,
             remote,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             payment_source_hex,
-            payment_max_budget,
+            payment_max_budget_mist,
             gas,
         } => {
             execute_agent_dag_skill(
@@ -758,9 +749,9 @@ pub(crate) async fn handle(command: TapCommand) -> AnyResult<(), NexusCliError> 
                 entry_group,
                 input_json,
                 remote,
-                priority_fee_per_gas_unit,
+                priority_fee_percentage,
                 payment_source_hex,
-                payment_max_budget,
+                payment_max_budget_mist,
                 gas.sui_gas_coin,
                 gas.sui_gas_budget,
             )
@@ -774,15 +765,15 @@ pub(crate) async fn handle(command: TapCommand) -> AnyResult<(), NexusCliError> 
             input_json,
             remote,
             metadata,
-            execution_priority_fee_per_gas_unit,
+            execution_priority_fee_percentage,
             schedule_start,
             schedule_deadline,
-            schedule_priority_fee_per_gas_unit,
+            schedule_priority_fee_percentage,
             generator,
             payment_source,
-            prepay_amount,
+            prepay_amount_mist,
             refund_recipient,
-            occurrence_budget,
+            occurrence_budget_mist,
             gas,
         } => {
             let crate::scheduler::task::ScheduleStartOptions {
@@ -800,16 +791,16 @@ pub(crate) async fn handle(command: TapCommand) -> AnyResult<(), NexusCliError> 
                 input_json,
                 remote,
                 metadata,
-                execution_priority_fee_per_gas_unit,
+                execution_priority_fee_percentage,
                 schedule_start_ms,
                 schedule_start_offset_ms,
                 schedule_deadline_offset_ms,
-                schedule_priority_fee_per_gas_unit,
+                schedule_priority_fee_percentage,
                 generator.into(),
                 payment_source,
-                prepay_amount,
+                prepay_amount_mist,
                 refund_recipient,
-                occurrence_budget,
+                occurrence_budget_mist,
                 gas.sui_gas_coin,
                 gas.sui_gas_budget,
             )
@@ -949,7 +940,7 @@ mod tests {
             dag_id: sui::types::Address::from_static("0xd"),
             interface_revision: 1,
             payment_mode: ArtifactPaymentMode::UserFunded,
-            agent_funded_max_budget: None,
+            agent_funded_max_budget_mist: None,
             recurrence_kind: "once".to_string(),
             min_interval_ms: 0,
             max_occurrences: 1,
@@ -1165,9 +1156,9 @@ mod tests {
             entry_group: DEFAULT_ENTRY_GROUP.to_string(),
             input_json: serde_json::json!({}),
             remote: Vec::new(),
-            priority_fee_per_gas_unit: 0,
+            priority_fee_percentage: None,
             payment_source_hex: "0xinvalid".to_string(),
-            payment_max_budget: 0,
+            payment_max_budget_mist: 0,
             gas: gas_args(),
         })
         .await
@@ -1662,7 +1653,7 @@ public struct WeatherSkill has drop {}
             agent_execute_options_from_cli("0x0102".to_string(), 99).expect("valid options");
 
         assert_eq!(options.payment_source, vec![1, 2]);
-        assert_eq!(options.payment_max_budget, 99);
+        assert_eq!(options.payment_max_budget_mist, 99);
     }
 
     #[test]

--- a/cli/src/tap/tap_common.rs
+++ b/cli/src/tap/tap_common.rs
@@ -21,13 +21,13 @@ pub(crate) fn decode_hex_arg(value: &str, name: &str) -> AnyResult<Vec<u8>, Nexu
 
 pub(crate) fn agent_execute_options_from_cli(
     payment_source_hex: String,
-    payment_max_budget: u64,
+    payment_max_budget_mist: u64,
 ) -> AnyResult<AgentDagExecuteOptions, NexusCliError> {
     Ok(AgentDagExecuteOptions {
         payment_source: decode_hex_arg(&payment_source_hex, "payment-source")?,
         payment_coin: None,
         payment_coin_balance: None,
-        payment_max_budget,
+        payment_max_budget_mist,
     })
 }
 

--- a/cli/src/tap/tap_create_skill_artifact.rs
+++ b/cli/src/tap/tap_create_skill_artifact.rs
@@ -23,7 +23,7 @@ pub(crate) async fn create_skill_artifact(
     dag_id: sui::types::Address,
     interface_revision: u64,
     payment_mode: ArtifactPaymentMode,
-    agent_funded_max_budget: Option<u64>,
+    agent_funded_max_budget_mist: Option<u64>,
     recurrence_kind: String,
     min_interval_ms: u64,
     max_occurrences: u64,
@@ -40,7 +40,7 @@ pub(crate) async fn create_skill_artifact(
         interface_revision,
         input_commitment,
         payment_mode,
-        agent_funded_max_budget,
+        agent_funded_max_budget_mist,
         recurrence_kind,
         min_interval_ms,
         max_occurrences,
@@ -68,7 +68,7 @@ fn build_artifact(
     interface_revision: u64,
     input_commitment: Vec<u8>,
     payment_mode: ArtifactPaymentMode,
-    agent_funded_max_budget: Option<u64>,
+    agent_funded_max_budget_mist: Option<u64>,
     recurrence_kind: String,
     min_interval_ms: u64,
     max_occurrences: u64,
@@ -79,7 +79,7 @@ fn build_artifact(
         return Err(NexusCliError::Any(anyhow!("skill name must not be empty")));
     }
 
-    let payment_policy = payment_policy_from_cli(payment_mode, agent_funded_max_budget)?;
+    let payment_policy = payment_policy_from_cli(payment_mode, agent_funded_max_budget_mist)?;
     let schedule_policy = schedule_policy_from_cli(
         &recurrence_kind,
         min_interval_ms,
@@ -134,29 +134,29 @@ async fn fetch_input_commitment(dag_id: sui::types::Address) -> AnyResult<Vec<u8
 
 fn payment_policy_from_cli(
     mode: ArtifactPaymentMode,
-    agent_funded_max_budget: Option<u64>,
+    agent_funded_max_budget_mist: Option<u64>,
 ) -> AnyResult<SkillPaymentPolicy, NexusCliError> {
     match mode {
         ArtifactPaymentMode::UserFunded => {
-            if let Some(max_budget) = agent_funded_max_budget {
+            if let Some(max_budget_mist) = agent_funded_max_budget_mist {
                 return Err(NexusCliError::Any(anyhow!(
-                    "--agent-funded-max-budget={max_budget} is only valid with --payment-mode agent-funded"
+                    "--agent-funded-max-budget-mist={max_budget_mist} is only valid with --payment-mode agent-funded"
                 )));
             }
             Ok(SkillPaymentPolicy::user_funded())
         }
         ArtifactPaymentMode::AgentFunded => {
-            let max_budget = agent_funded_max_budget.ok_or_else(|| {
+            let max_budget_mist = agent_funded_max_budget_mist.ok_or_else(|| {
                 NexusCliError::Any(anyhow!(
-                    "--agent-funded-max-budget is required with --payment-mode agent-funded"
+                    "--agent-funded-max-budget-mist is required with --payment-mode agent-funded"
                 ))
             })?;
-            if max_budget == 0 {
+            if max_budget_mist == 0 {
                 return Err(NexusCliError::Any(anyhow!(
-                    "--agent-funded-max-budget must be greater than zero"
+                    "--agent-funded-max-budget-mist must be greater than zero"
                 )));
             }
-            Ok(SkillPaymentPolicy::agent_funded(max_budget))
+            Ok(SkillPaymentPolicy::agent_funded(max_budget_mist))
         }
     }
 }
@@ -258,7 +258,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("--agent-funded-max-budget is required"),
+                .contains("--agent-funded-max-budget-mist is required"),
             "unexpected error: {error}"
         );
     }

--- a/cli/src/tap/tap_execute.rs
+++ b/cli/src/tap/tap_execute.rs
@@ -7,15 +7,15 @@ pub(crate) async fn execute_agent_dag_skill(
     entry_group: String,
     input_json: serde_json::Value,
     remote: Vec<String>,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     payment_source_hex: String,
-    payment_max_budget: u64,
+    payment_max_budget_mist: u64,
     sui_gas_coin: Option<sui::types::Address>,
     sui_gas_budget: u64,
 ) -> AnyResult<(), NexusCliError> {
     command_title!("Executing agent DAG skill '{agent_id}:{skill_id}'");
 
-    let options = agent_execute_options_from_cli(payment_source_hex, payment_max_budget)?;
+    let options = agent_execute_options_from_cli(payment_source_hex, payment_max_budget_mist)?;
     let nexus_client = get_nexus_client(sui_gas_coin, sui_gas_budget).await?;
     ensure_cli_mutable_agent(&nexus_client, agent_id).await?;
     let conf = CliConf::load().await.unwrap_or_default();
@@ -31,7 +31,7 @@ pub(crate) async fn execute_agent_dag_skill(
             agent_id,
             skill_id,
             input_data,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             Some(&entry_group),
             &storage_conf,
             options,
@@ -76,7 +76,7 @@ mod tests {
             DEFAULT_ENTRY_GROUP.to_string(),
             serde_json::json!({}),
             Vec::new(),
-            0,
+            None,
             "0xinvalid".to_string(),
             0,
             None,

--- a/cli/src/tap/tap_output.rs
+++ b/cli/src/tap/tap_output.rs
@@ -163,7 +163,7 @@ pub(crate) fn agent_execute_result_json(
             "skill_id": submit.skill_id,
             "dag_id": submit.dag_id,
             "skill_revision_key": submit.skill_revision_key,
-            "payment_max_budget": submit.payment_max_budget,
+            "payment_max_budget_mist": submit.payment_max_budget_mist,
         }))
     })
 }
@@ -197,8 +197,8 @@ pub(crate) fn schedule_task_result_json(
         "tap_payment": result.tap_payment.as_ref().map(|payment| json!({
             "agent_id": payment.agent_id,
             "skill_id": payment.skill_id,
-            "prepay_amount": payment.prepay_amount,
-            "occurrence_budget": payment.occurrence_budget,
+            "prepay_amount_mist": payment.prepay_amount_mist,
+            "occurrence_budget_mist": payment.occurrence_budget_mist,
         })),
         "initial_schedule": result.initial_schedule.as_ref().map(|schedule| json!({
             "digest": schedule.tx_digest,
@@ -259,8 +259,8 @@ pub(crate) fn payment_show_result_json(payment: &ExecutionPayment) -> serde_json
         "interface_revision": payment.interface_revision,
         "payment_policy": payment.payment_policy,
         "source_kind": payment.source_kind,
-        "max_budget": payment.max_budget,
-        "locked_budget": payment.locked_budget,
+        "max_budget_mist": payment.max_budget_mist,
+        "locked_budget_mist": payment.locked_budget_mist,
         "funds": payment.funds,
         "consumed": payment.consumed,
         "accomplished": payment.accomplished,
@@ -483,8 +483,10 @@ mod tests {
                 nexus_sdk::move_bindings::interface::payment::PaymentSourceKind::user_funded(
                     sui::types::Address::from_static("0xee"),
                 ),
-            max_budget: 1_000,
-            locked_budget: 0,
+            max_budget_mist: 1_000,
+            gas_budget_mist: 333,
+            priority_fee_reserve_mist: 666,
+            locked_budget_mist: 0,
             funds: nexus_sdk::move_bindings::sui_framework::balance::Balance {
                 value: 1_000,
                 phantom_t0: std::marker::PhantomData,
@@ -497,6 +499,9 @@ mod tests {
             refunded,
             final_state,
             locked_vertices: vec![],
+            tool_fee_charged: 0,
+            priority_fee_charged: 0,
+            priority_fee_percentage: 200,
         }
     }
 
@@ -634,7 +639,7 @@ mod tests {
                     skill_id: 11,
                     interface_revision: InterfaceVersion::new(3),
                 },
-                payment_max_budget: 99,
+                payment_max_budget_mist: 99,
             }),
         };
 
@@ -654,7 +659,7 @@ mod tests {
             serde_json::json!({ "inner": 3 })
         );
         assert_eq!(
-            output["submit"]["payment_max_budget"],
+            output["submit"]["payment_max_budget_mist"],
             serde_json::json!(99)
         );
     }
@@ -697,8 +702,8 @@ mod tests {
             tap_payment: Some(nexus_sdk::nexus::scheduler::CreateTaskTapPaymentResult {
                 agent_id: sui::types::Address::from_static("0xa"),
                 skill_id: 11,
-                prepay_amount: 500,
-                occurrence_budget: 50,
+                prepay_amount_mist: 500,
+                occurrence_budget_mist: 50,
             }),
         };
 
@@ -719,11 +724,11 @@ mod tests {
             serde_json::json!(sui::types::Address::from_static("0xd").to_string())
         );
         assert_eq!(
-            output["tap_payment"]["prepay_amount"],
+            output["tap_payment"]["prepay_amount_mist"],
             serde_json::json!(500)
         );
         assert_eq!(
-            output["tap_payment"]["occurrence_budget"],
+            output["tap_payment"]["occurrence_budget_mist"],
             serde_json::json!(50)
         );
         assert!(output["initial_schedule"].is_null());

--- a/cli/src/tap/tap_payments.rs
+++ b/cli/src/tap/tap_payments.rs
@@ -158,12 +158,10 @@ async fn list_payments(
 }
 
 /// Wrap the on-chain `nexus_workflow::execution_settlement::accomplish_tap_execution_payment*`
-/// PTBs. With no agent supplied, the SDK builds the invoker-funded PTB
-/// (`accomplish_tap_execution_payment`) and the shared `DAGExecution` is
-/// the only input. When `--alias` or `--agent-id` resolves to an agent,
-/// the SDK additionally fetches the agent's object ref and routes through
-/// `accomplish_tap_execution_payment_from_agent_vault` so the payment
-/// settles out of the agent's vault.
+/// PTBs. With no agent supplied, the SDK builds the invoker-funded accomplishment
+/// PTB. When `--alias` or `--agent-id` resolves to an agent, the SDK
+/// additionally fetches the agent's object ref and routes through the
+/// agent-vault accomplishment path.
 async fn resolve_payment(
     execution_id: sui::types::Address,
     alias: Option<String>,

--- a/cli/src/tap/tap_schedule_task.rs
+++ b/cli/src/tap/tap_schedule_task.rs
@@ -7,6 +7,7 @@ use {
             scheduler::{CreateTaskParams, CreateTaskTapPayment, GeneratorKind, OccurrenceRequest},
             tap::fetch_configured_active_tap_skill_execution_target,
         },
+        types::effective_priority_fee_percentage,
         walrus::StorageConf,
     },
     std::collections::HashMap,
@@ -18,6 +19,20 @@ pub(crate) enum TapTaskPaymentSourceArg {
     AgentFunded,
 }
 
+fn validated_priority_fee_percentages(
+    execution_priority_fee_percentage: Option<u64>,
+    schedule_priority_fee_percentage: Option<u64>,
+) -> AnyResult<(Option<u64>, Option<u64>), NexusCliError> {
+    effective_priority_fee_percentage(execution_priority_fee_percentage)
+        .map_err(NexusCliError::Any)?;
+    effective_priority_fee_percentage(schedule_priority_fee_percentage)
+        .map_err(NexusCliError::Any)?;
+    Ok((
+        execution_priority_fee_percentage,
+        schedule_priority_fee_percentage,
+    ))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn schedule_tap_task(
     agent_id: sui::types::Address,
@@ -27,19 +42,25 @@ pub(crate) async fn schedule_tap_task(
     mut input_json: Option<serde_json::Value>,
     remote: Vec<String>,
     metadata: Vec<String>,
-    execution_priority_fee_per_gas_unit: u64,
+    execution_priority_fee_percentage: Option<u64>,
     schedule_start_ms: Option<u64>,
     schedule_start_offset_ms: Option<u64>,
     schedule_deadline_offset_ms: Option<u64>,
-    schedule_priority_fee_per_gas_unit: u64,
+    schedule_priority_fee_percentage: Option<u64>,
     generator: GeneratorKind,
     payment_source: TapTaskPaymentSourceArg,
-    prepay_amount: u64,
+    prepay_amount_mist: u64,
     refund_recipient: Option<sui::types::Address>,
-    occurrence_budget: u64,
+    occurrence_budget_mist: u64,
     sui_gas_coin: Option<sui::types::Address>,
     sui_gas_budget: u64,
 ) -> AnyResult<(), NexusCliError> {
+    let (execution_priority_fee_percentage, schedule_priority_fee_percentage) =
+        validated_priority_fee_percentages(
+            execution_priority_fee_percentage,
+            schedule_priority_fee_percentage,
+        )?;
+
     if matches!(payment_source, TapTaskPaymentSourceArg::AgentFunded) && refund_recipient.is_some()
     {
         return Err(NexusCliError::Any(anyhow!(
@@ -105,7 +126,7 @@ pub(crate) async fn schedule_tap_task(
                 None,
                 schedule_start_offset_ms,
                 schedule_deadline_offset_ms,
-                schedule_priority_fee_per_gas_unit,
+                schedule_priority_fee_percentage,
                 true,
             )
             .map_err(NexusCliError::Nexus)?,
@@ -122,15 +143,15 @@ pub(crate) async fn schedule_tap_task(
 
     let tap_payment = match payment_source {
         TapTaskPaymentSourceArg::UserFunded => CreateTaskTapPayment::UserFunded {
-            prepay_amount,
+            prepay_amount_mist,
             refund_recipient,
-            occurrence_budget,
+            occurrence_budget_mist,
             selected_dag: runtime_selected_dag,
             authorization_templates: Vec::new(),
         },
         TapTaskPaymentSourceArg::AgentFunded => CreateTaskTapPayment::AgentFunded {
-            prepay_amount,
-            occurrence_budget,
+            prepay_amount_mist,
+            occurrence_budget_mist,
             selected_dag: runtime_selected_dag,
             authorization_templates: Vec::new(),
         },
@@ -144,7 +165,7 @@ pub(crate) async fn schedule_tap_task(
             entry_group: entry_group.clone(),
             input_data,
             metadata: metadata_pairs,
-            execution_priority_fee_per_gas_unit,
+            execution_priority_fee_percentage,
             initial_schedule,
             generator,
             agent_id: Some(agent_id),
@@ -197,6 +218,61 @@ fn resolve_scheduled_tap_dag_selection(
 mod tests {
     use super::*;
 
+    #[test]
+    fn omitted_cli_priority_fee_percentages_reach_validation_as_none() {
+        let cli = crate::Cli::try_parse_from([
+            "nexus",
+            "tap",
+            "schedule-task",
+            "--agent-id",
+            "0xa",
+            "--skill-id",
+            "7",
+            "--payment-source",
+            "user-funded",
+            "--prepay-amount-mist",
+            "1",
+            "--occurrence-budget-mist",
+            "1",
+        ])
+        .expect("schedule-task arguments parse");
+        let crate::Command::Tap(TapCommand::ScheduleTask {
+            execution_priority_fee_percentage,
+            schedule_priority_fee_percentage,
+            ..
+        }) = cli.command
+        else {
+            panic!("expected TAP schedule-task command")
+        };
+        let percentages = validated_priority_fee_percentages(
+            execution_priority_fee_percentage,
+            schedule_priority_fee_percentage,
+        )
+        .expect("omitted percentages are valid");
+
+        assert_eq!(percentages, (None, None));
+    }
+
+    #[test]
+    fn explicit_zero_priority_fee_percentage_is_rejected() {
+        let err = validated_priority_fee_percentages(Some(0), None)
+            .expect_err("explicit zero must fail SDK percentage validation");
+
+        assert!(
+            err.to_string()
+                .contains("priority fee percentage must be in"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn valid_explicit_priority_fee_percentages_are_forwarded() {
+        let percentages = validated_priority_fee_percentages(Some(10), Some(25))
+            .expect("valid explicit percentages are accepted");
+
+        assert_eq!(percentages, (Some(10), Some(25)));
+    }
+
     #[tokio::test]
     async fn schedule_tap_task_rejects_refund_for_agent_vault_before_rpc() {
         let err = schedule_tap_task(
@@ -207,11 +283,11 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
-            0,
             None,
             None,
             None,
-            0,
+            None,
+            None,
             GeneratorKind::Queue,
             TapTaskPaymentSourceArg::AgentFunded,
             1,

--- a/sdk/src/events/mod.rs
+++ b/sdk/src/events/mod.rs
@@ -221,6 +221,7 @@ events! {
     crate::move_bindings::workflow::execution_events::WalkCancelledEvent => WalkCancelled, "WalkCancelledEvent",
     crate::move_bindings::workflow::execution_events::EndStateReachedEvent => EndStateReached, "EndStateReachedEvent",
     crate::move_bindings::workflow::execution_events::ExecutionFinishedEvent => ExecutionFinished, "ExecutionFinishedEvent",
+    crate::move_bindings::workflow::execution_events::ExecutionPaymentInsufficientSettlementEvent => ExecutionPaymentInsufficientSettlement, "ExecutionPaymentInsufficientSettlementEvent",
     crate::move_bindings::scheduler::scheduler::MissedOccurrenceEvent => MissedOccurrence, "MissedOccurrenceEvent",
     crate::move_bindings::scheduler::scheduler::OccurrenceConsumedEvent => OccurrenceConsumed, "OccurrenceConsumedEvent",
     crate::move_bindings::scheduler::scheduler::PeriodicScheduleConfiguredEvent => PeriodicScheduleConfigured, "PeriodicScheduleConfiguredEvent",

--- a/sdk/src/events/parsing.rs
+++ b/sdk/src/events/parsing.rs
@@ -843,8 +843,11 @@ mod direct_event_tests {
                 interface_revision: interface_version(26),
                 payment_policy: payment_types::SkillPaymentPolicy::UserFunded,
                 source_kind: payment_source(),
-                max_budget: 27,
-                locked_budget: 28,
+                max_budget_mist: 27,
+                gas_budget_mist: 23,
+                priority_fee_reserve_mist: 4,
+                locked_budget_mist: 28,
+                priority_fee_percentage: 20,
             }
         );
         check!(
@@ -882,8 +885,8 @@ mod direct_event_tests {
                 skill_id: 30,
                 interface_version: interface_version(31),
                 source_kind: payment_source(),
-                prepaid_amount: 32,
-                occurrence_budget: 33,
+                prepaid_amount_mist: 32,
+                occurrence_budget_mist: 33,
                 stored_under_agent: false,
             }
         );
@@ -963,7 +966,7 @@ mod direct_event_tests {
                 interface_version: interface_version(43),
                 source_kind: payment_source(),
                 refill_amount: 44,
-                occurrence_budget: 45,
+                occurrence_budget_mist: 45,
                 remaining_funds: 46,
             }
         );
@@ -1168,6 +1171,15 @@ mod direct_event_tests {
             }
         );
         check!(
+            "ExecutionPaymentInsufficientSettlementEvent",
+            check!(@tag objects.workflow_pkg_id, "execution_events", "ExecutionPaymentInsufficientSettlementEvent"),
+            ExecutionPaymentInsufficientSettlementEvent {
+                execution: id(addr(0x5d)),
+                walk_index: 70,
+                required_shortfall: 71,
+            }
+        );
+        check!(
             "MissedOccurrenceEvent",
             check!(@tag objects.scheduler_pkg_id, "scheduler", "MissedOccurrenceEvent"),
             MissedOccurrenceEvent {
@@ -1175,7 +1187,7 @@ mod direct_event_tests {
                 start_time_ms: 70,
                 deadline_ms: MoveOption::from_option(Some(71)),
                 pruned_at: 72,
-                priority_fee_per_gas_unit: 73,
+                priority_fee_percentage: 73,
                 generator: generator(),
             }
         );
@@ -1186,7 +1198,7 @@ mod direct_event_tests {
                 task: id(addr(0x5e)),
                 start_time_ms: 74,
                 deadline_ms: MoveOption::from_option(None),
-                priority_fee_per_gas_unit: 75,
+                priority_fee_percentage: 75,
                 generator: generator(),
                 executed_at: 76,
             }
@@ -1200,7 +1212,7 @@ mod direct_event_tests {
                 deadline_offset_ms: MoveOption::from_option(Some(78)),
                 max_iterations: MoveOption::from_option(Some(79)),
                 generated: MoveOption::from_option(Some(80)),
-                priority_fee_per_gas_unit: 81,
+                priority_fee_percentage: 81,
                 last_generated_start_ms: MoveOption::from_option(Some(82)),
             }
         );
@@ -1277,6 +1289,6 @@ mod direct_event_tests {
             }
         );
 
-        assert_eq!(parsed, 46);
+        assert_eq!(parsed, 47);
     }
 }

--- a/sdk/src/move_bindings/extensions/tap.rs
+++ b/sdk/src/move_bindings/extensions/tap.rs
@@ -64,14 +64,14 @@ impl SkillPaymentPolicy {
         Self::UserFunded
     }
 
-    pub fn agent_funded(max_budget: u64) -> Self {
-        Self::AgentFunded { max_budget }
+    pub fn agent_funded(max_budget_mist: u64) -> Self {
+        Self::AgentFunded { max_budget_mist }
     }
 
-    pub fn max_budget(&self) -> u64 {
+    pub fn max_budget_mist(&self) -> u64 {
         match self {
             Self::UserFunded => 0,
-            Self::AgentFunded { max_budget } => *max_budget,
+            Self::AgentFunded { max_budget_mist } => *max_budget_mist,
         }
     }
 }

--- a/sdk/src/move_bindings/ir/interface.json
+++ b/sdk/src/move_bindings/ir/interface.json
@@ -230,7 +230,7 @@
                   "ty": "Address"
                 },
                 {
-                  "name": "priority_fee_per_gas_unit",
+                  "name": "priority_fee_percentage",
                   "position": 5,
                   "ty": "U64"
                 },
@@ -2517,7 +2517,7 @@
               }
             },
             {
-              "name": "priority_fee_per_gas_unit",
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -2678,7 +2678,11 @@
               }
             },
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -2772,7 +2776,11 @@
               }
             },
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -3017,7 +3025,7 @@
               }
             },
             {
-              "name": "priority_fee_per_gas_unit",
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -3257,7 +3265,7 @@
               "ty": "Address"
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -3398,11 +3406,11 @@
               "ty": "U64"
             },
             {
-              "name": "prepay_amount",
+              "name": "prepay_amount_mist",
               "ty": "U64"
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -13595,13 +13603,28 @@
                   }
                 },
                 {
-                  "name": "max_budget",
+                  "name": "max_budget_mist",
                   "position": 7,
                   "ty": "U64"
                 },
                 {
-                  "name": "locked_budget",
+                  "name": "gas_budget_mist",
                   "position": 8,
+                  "ty": "U64"
+                },
+                {
+                  "name": "priority_fee_reserve_mist",
+                  "position": 9,
+                  "ty": "U64"
+                },
+                {
+                  "name": "locked_budget_mist",
+                  "position": 10,
+                  "ty": "U64"
+                },
+                {
+                  "name": "priority_fee_percentage",
+                  "position": 11,
                   "ty": "U64"
                 }
               ]
@@ -13802,18 +13825,28 @@
                   }
                 },
                 {
-                  "name": "max_budget",
+                  "name": "max_budget_mist",
                   "position": 7,
                   "ty": "U64"
                 },
                 {
-                  "name": "locked_budget",
+                  "name": "gas_budget_mist",
                   "position": 8,
                   "ty": "U64"
                 },
                 {
-                  "name": "funds",
+                  "name": "priority_fee_reserve_mist",
                   "position": 9,
+                  "ty": "U64"
+                },
+                {
+                  "name": "locked_budget_mist",
+                  "position": 10,
+                  "ty": "U64"
+                },
+                {
+                  "name": "funds",
+                  "position": 11,
                   "ty": {
                     "Datatype": {
                       "type_name": {
@@ -13838,22 +13871,37 @@
                 },
                 {
                   "name": "consumed",
-                  "position": 10,
+                  "position": 12,
+                  "ty": "U64"
+                },
+                {
+                  "name": "tool_fee_charged",
+                  "position": 13,
+                  "ty": "U64"
+                },
+                {
+                  "name": "priority_fee_charged",
+                  "position": 14,
+                  "ty": "U64"
+                },
+                {
+                  "name": "priority_fee_percentage",
+                  "position": 15,
                   "ty": "U64"
                 },
                 {
                   "name": "accomplished",
-                  "position": 11,
+                  "position": 16,
                   "ty": "Bool"
                 },
                 {
                   "name": "refunded",
-                  "position": 12,
+                  "position": 17,
                   "ty": "Bool"
                 },
                 {
                   "name": "final_state",
-                  "position": 13,
+                  "position": 18,
                   "ty": {
                     "Datatype": {
                       "type_name": {
@@ -13867,7 +13915,7 @@
                 },
                 {
                   "name": "tool_cost_snapshot",
-                  "position": 14,
+                  "position": 19,
                   "ty": {
                     "Datatype": {
                       "type_name": {
@@ -13886,7 +13934,7 @@
                 },
                 {
                   "name": "locked_vertices",
-                  "position": 15,
+                  "position": 20,
                   "ty": {
                     "Vector": {
                       "Datatype": {
@@ -13899,6 +13947,75 @@
                       }
                     }
                   }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type_name": {
+            "address": "0xa2",
+            "module": "payment",
+            "name": "ExecutionPaymentFeesRecordedEvent"
+          },
+          "module": "payment",
+          "name": "ExecutionPaymentFeesRecordedEvent",
+          "abilities": [
+            "Copy",
+            "Drop"
+          ],
+          "type_parameters": [],
+          "kind": {
+            "Struct": {
+              "fields": [
+                {
+                  "name": "payment_id",
+                  "position": 0,
+                  "ty": "Address"
+                },
+                {
+                  "name": "execution_id",
+                  "position": 1,
+                  "ty": "Address"
+                },
+                {
+                  "name": "agent_id",
+                  "position": 2,
+                  "ty": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "object",
+                        "name": "ID"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                },
+                {
+                  "name": "skill_id",
+                  "position": 3,
+                  "ty": "U64"
+                },
+                {
+                  "name": "gas_fee_mist",
+                  "position": 4,
+                  "ty": "U64"
+                },
+                {
+                  "name": "tool_fee_mist",
+                  "position": 5,
+                  "ty": "U64"
+                },
+                {
+                  "name": "priority_fee_mist",
+                  "position": 6,
+                  "ty": "U64"
+                },
+                {
+                  "name": "priority_fee_percentage",
+                  "position": 7,
+                  "ty": "U64"
                 }
               ]
             }
@@ -14055,7 +14172,7 @@
                   }
                 },
                 {
-                  "name": "max_budget",
+                  "name": "max_budget_mist",
                   "position": 6,
                   "ty": "U64"
                 },
@@ -15069,7 +15186,7 @@
                   }
                 },
                 {
-                  "name": "occurrence_budget",
+                  "name": "occurrence_budget_mist",
                   "position": 7,
                   "ty": "U64"
                 },
@@ -15236,12 +15353,12 @@
                   }
                 },
                 {
-                  "name": "prepaid_amount",
+                  "name": "prepaid_amount_mist",
                   "position": 7,
                   "ty": "U64"
                 },
                 {
-                  "name": "occurrence_budget",
+                  "name": "occurrence_budget_mist",
                   "position": 8,
                   "ty": "U64"
                 },
@@ -15338,12 +15455,12 @@
                   }
                 },
                 {
-                  "name": "prepaid_amount",
+                  "name": "prepaid_amount_mist",
                   "position": 7,
                   "ty": "U64"
                 },
                 {
-                  "name": "occurrence_budget",
+                  "name": "occurrence_budget_mist",
                   "position": 8,
                   "ty": "U64"
                 },
@@ -15522,7 +15639,7 @@
                   "ty": "U64"
                 },
                 {
-                  "name": "occurrence_budget",
+                  "name": "occurrence_budget_mist",
                   "position": 7,
                   "ty": "U64"
                 },
@@ -15562,7 +15679,7 @@
                   "position": 1,
                   "fields": [
                     {
-                      "name": "max_budget",
+                      "name": "max_budget_mist",
                       "position": 0,
                       "ty": "U64"
                     }
@@ -15855,6 +15972,33 @@
           "return_types": []
         },
         {
+          "name": "assert_payment_charges_within_budget",
+          "visibility": "Private",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": []
+        },
+        {
           "name": "assert_payment_policy",
           "visibility": "Public",
           "is_entry": false,
@@ -15905,7 +16049,7 @@
               }
             },
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
               "ty": "U64"
             }
           ],
@@ -16000,6 +16144,26 @@
             }
           ],
           "return_types": []
+        },
+        {
+          "name": "budget_split_mist",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            "U64",
+            "U64"
+          ]
         },
         {
           "name": "can_lock_payment_vertex_with_amount",
@@ -16139,6 +16303,44 @@
                 ]
               }
             }
+          ]
+        },
+        {
+          "name": "checked_add_u64",
+          "visibility": "Private",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "left",
+              "ty": "U64"
+            },
+            {
+              "name": "right",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "checked_percent_floor",
+          "visibility": "Private",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "value",
+              "ty": "U64"
+            },
+            {
+              "name": "percent",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            "U64"
           ]
         },
         {
@@ -16316,6 +16518,59 @@
           "return_types": []
         },
         {
+          "name": "consume_priority_fee_for_settlement",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "priority_delta",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            {
+              "Datatype": {
+                "type_name": {
+                  "address": "0x2",
+                  "module": "balance",
+                  "name": "Balance"
+                },
+                "type_arguments": [
+                  {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "sui",
+                        "name": "SUI"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
           "name": "destroy_execution_payment_receipt_unchecked_for_testing",
           "visibility": "Public",
           "is_entry": false,
@@ -16331,6 +16586,33 @@
                     "name": "ExecutionPaymentReceipt"
                   },
                   "type_arguments": []
+                }
+              }
+            }
+          ],
+          "return_types": []
+        },
+        {
+          "name": "emit_execution_payment_fees_recorded",
+          "visibility": "Private",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
                 }
               }
             }
@@ -16759,6 +17041,25 @@
           ]
         },
         {
+          "name": "gas_budget_mist_for_max_budget_mist",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
           "name": "lock_execution_payment_vertex_internal",
           "visibility": "Private",
           "is_entry": false,
@@ -16998,7 +17299,11 @@
               }
             },
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -17138,7 +17443,11 @@
               }
             },
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -17372,7 +17681,11 @@
               }
             },
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -17482,6 +17795,10 @@
               "ty": "U64"
             },
             {
+              "name": "priority_fee_percentage",
+              "ty": "U64"
+            },
+            {
               "name": "ctx",
               "ty": {
                 "Ref": {
@@ -17585,7 +17902,7 @@
               }
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -17738,7 +18055,7 @@
               }
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -17882,7 +18199,7 @@
               }
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -17993,11 +18310,11 @@
               }
             },
             {
-              "name": "prepaid_amount",
+              "name": "prepaid_amount_mist",
               "ty": "U64"
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -18101,6 +18418,68 @@
         },
         {
           "name": "payment_available_gas",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "payment_available_settlement_charge",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "payable_leader_gas",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "payment_available_settlement_funds",
           "visibility": "Public",
           "is_entry": false,
           "type_parameters": [],
@@ -18283,6 +18662,35 @@
         },
         {
           "name": "payment_funds",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "payment_gas_budget_mist",
           "visibility": "Public",
           "is_entry": false,
           "type_parameters": [],
@@ -18506,6 +18914,35 @@
           ]
         },
         {
+          "name": "payment_leader_gas_consumed",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
           "name": "payment_locked_amount",
           "visibility": "Private",
           "is_entry": false,
@@ -18535,7 +18972,7 @@
           ]
         },
         {
-          "name": "payment_locked_budget",
+          "name": "payment_locked_budget_mist",
           "visibility": "Public",
           "is_entry": false,
           "type_parameters": [],
@@ -18593,7 +19030,7 @@
           ]
         },
         {
-          "name": "payment_max_budget",
+          "name": "payment_max_budget_mist",
           "visibility": "Public",
           "is_entry": false,
           "type_parameters": [],
@@ -18628,7 +19065,7 @@
           "type_parameters": [],
           "parameters": [
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
               "ty": "U64"
             }
           ],
@@ -18670,7 +19107,7 @@
           ]
         },
         {
-          "name": "payment_policy_max_budget",
+          "name": "payment_policy_max_budget_mist",
           "visibility": "Public",
           "is_entry": false,
           "type_parameters": [],
@@ -18710,6 +19147,93 @@
                 "type_arguments": []
               }
             }
+          ]
+        },
+        {
+          "name": "payment_priority_fee_charged",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "payment_priority_fee_percentage",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "payment_priority_fee_reserve_mist",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            "U64"
           ]
         },
         {
@@ -19122,6 +19646,107 @@
           "return_types": [
             "Bool"
           ]
+        },
+        {
+          "name": "priority_charge_for",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "priority_fee_mist_for_gas_budget",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "gas_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "priority_fee_percentage",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "priority_fee_percentage",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0x1",
+                    "module": "option",
+                    "name": "Option"
+                  },
+                  "type_arguments": [
+                    "U64"
+                  ]
+                }
+              }
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "recompute_payment_budget_split",
+          "visibility": "Private",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": []
         },
         {
           "name": "refill_execution_payment_from_agent_vault_balance",
@@ -20005,7 +20630,7 @@
           ]
         },
         {
-          "name": "scheduled_occurrence_record_budget",
+          "name": "scheduled_occurrence_record_budget_mist",
           "visibility": "Public",
           "is_entry": false,
           "type_parameters": [],
@@ -20340,7 +20965,7 @@
           ]
         },
         {
-          "name": "scheduled_payment_reserve_occurrence_budget",
+          "name": "scheduled_payment_reserve_occurrence_budget_mist",
           "visibility": "Public",
           "is_entry": false,
           "type_parameters": [],
@@ -21049,6 +21674,105 @@
                 "type_arguments": []
               }
             }
+          ]
+        },
+        {
+          "name": "settlement_charge_missing",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "payable_leader_gas",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "settlement_charge_required",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "payable_leader_gas",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            "U64"
+          ]
+        },
+        {
+          "name": "settlement_priority_delta_for_leader_gas",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "payment",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "payment",
+                        "name": "ExecutionPayment"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "payable_leader_gas",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            "U64"
           ]
         },
         {

--- a/sdk/src/move_bindings/ir/registry.json
+++ b/sdk/src/move_bindings/ir/registry.json
@@ -1937,7 +1937,11 @@
               }
             },
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -2023,7 +2027,11 @@
               "ty": "Address"
             },
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -2111,7 +2119,11 @@
               }
             },
             {
-              "name": "max_budget",
+              "name": "max_budget_mist",
+              "ty": "U64"
+            },
+            {
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -2222,7 +2234,7 @@
               }
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -5257,6 +5269,46 @@
                       ]
                     }
                   }
+                }
+              }
+            }
+          ],
+          "return_types": []
+        },
+        {
+          "name": "assert_registered",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "self",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_cap_id",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0x2",
+                    "module": "object",
+                    "name": "ID"
+                  },
+                  "type_arguments": []
                 }
               }
             }
@@ -10041,6 +10093,780 @@
           ],
           "return_types": [
             "Bool"
+          ]
+        }
+      ]
+    },
+    "priority_fee_vault": {
+      "name": "priority_fee_vault",
+      "datatypes": [
+        {
+          "type_name": {
+            "address": "0xa3",
+            "module": "priority_fee_vault",
+            "name": "PriorityFeeAccount"
+          },
+          "module": "priority_fee_vault",
+          "name": "PriorityFeeAccount",
+          "abilities": [
+            "Copy",
+            "Drop",
+            "Store"
+          ],
+          "type_parameters": [],
+          "kind": {
+            "Struct": {
+              "fields": [
+                {
+                  "name": "accrued",
+                  "position": 0,
+                  "ty": "U64"
+                },
+                {
+                  "name": "withdrawn",
+                  "position": 1,
+                  "ty": "U64"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type_name": {
+            "address": "0xa3",
+            "module": "priority_fee_vault",
+            "name": "PriorityFeeDeposit"
+          },
+          "module": "priority_fee_vault",
+          "name": "PriorityFeeDeposit",
+          "abilities": [
+            "Store"
+          ],
+          "type_parameters": [],
+          "kind": {
+            "Struct": {
+              "fields": [
+                {
+                  "name": "amount",
+                  "position": 0,
+                  "ty": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "balance",
+                        "name": "Balance"
+                      },
+                      "type_arguments": [
+                        {
+                          "Datatype": {
+                            "type_name": {
+                              "address": "0x2",
+                              "module": "sui",
+                              "name": "SUI"
+                            },
+                            "type_arguments": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "name": "leader_cap_id",
+                  "position": 1,
+                  "ty": "Address"
+                },
+                {
+                  "name": "charged_amount",
+                  "position": 2,
+                  "ty": "U64"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type_name": {
+            "address": "0xa3",
+            "module": "priority_fee_vault",
+            "name": "PriorityFeeDepositedEvent"
+          },
+          "module": "priority_fee_vault",
+          "name": "PriorityFeeDepositedEvent",
+          "abilities": [
+            "Copy",
+            "Drop"
+          ],
+          "type_parameters": [],
+          "kind": {
+            "Struct": {
+              "fields": [
+                {
+                  "name": "vault",
+                  "position": 0,
+                  "ty": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "object",
+                        "name": "ID"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                },
+                {
+                  "name": "leader_cap_id",
+                  "position": 1,
+                  "ty": "Address"
+                },
+                {
+                  "name": "amount",
+                  "position": 2,
+                  "ty": "U64"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type_name": {
+            "address": "0xa3",
+            "module": "priority_fee_vault",
+            "name": "PriorityFeeVault"
+          },
+          "module": "priority_fee_vault",
+          "name": "PriorityFeeVault",
+          "abilities": [
+            "Key"
+          ],
+          "type_parameters": [],
+          "kind": {
+            "Struct": {
+              "fields": [
+                {
+                  "name": "id",
+                  "position": 0,
+                  "ty": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "object",
+                        "name": "UID"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                },
+                {
+                  "name": "balance",
+                  "position": 1,
+                  "ty": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "balance",
+                        "name": "Balance"
+                      },
+                      "type_arguments": [
+                        {
+                          "Datatype": {
+                            "type_name": {
+                              "address": "0x2",
+                              "module": "sui",
+                              "name": "SUI"
+                            },
+                            "type_arguments": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "name": "leader_accounts",
+                  "position": 2,
+                  "ty": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "vec_map",
+                        "name": "VecMap"
+                      },
+                      "type_arguments": [
+                        "Address",
+                        {
+                          "Datatype": {
+                            "type_name": {
+                              "address": "0xa3",
+                              "module": "priority_fee_vault",
+                              "name": "PriorityFeeAccount"
+                            },
+                            "type_arguments": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type_name": {
+            "address": "0xa3",
+            "module": "priority_fee_vault",
+            "name": "PriorityFeeWithdrawnEvent"
+          },
+          "module": "priority_fee_vault",
+          "name": "PriorityFeeWithdrawnEvent",
+          "abilities": [
+            "Copy",
+            "Drop"
+          ],
+          "type_parameters": [],
+          "kind": {
+            "Struct": {
+              "fields": [
+                {
+                  "name": "vault",
+                  "position": 0,
+                  "ty": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "object",
+                        "name": "ID"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                },
+                {
+                  "name": "leader_cap_id",
+                  "position": 1,
+                  "ty": "Address"
+                },
+                {
+                  "name": "amount",
+                  "position": 2,
+                  "ty": "U64"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "functions": [
+        {
+          "name": "accrue_for_leader",
+          "visibility": "Private",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "self",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_cap_id",
+              "ty": "Address"
+            },
+            {
+              "name": "amount",
+              "ty": "U64"
+            }
+          ],
+          "return_types": []
+        },
+        {
+          "name": "deposit",
+          "visibility": "Private",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "self",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "deposit",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0xa3",
+                    "module": "priority_fee_vault",
+                    "name": "PriorityFeeDeposit"
+                  },
+                  "type_arguments": []
+                }
+              }
+            }
+          ],
+          "return_types": []
+        },
+        {
+          "name": "deposit_balance",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "self",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_cap_id",
+              "ty": "Address"
+            },
+            {
+              "name": "amount",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0x2",
+                    "module": "balance",
+                    "name": "Balance"
+                  },
+                  "type_arguments": [
+                    {
+                      "Datatype": {
+                        "type_name": {
+                          "address": "0x2",
+                          "module": "sui",
+                          "name": "SUI"
+                        },
+                        "type_arguments": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "charged_amount",
+              "ty": "U64"
+            }
+          ],
+          "return_types": []
+        },
+        {
+          "name": "leader_account",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "self",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_cap_id",
+              "ty": "Address"
+            }
+          ],
+          "return_types": [
+            "U64",
+            "U64",
+            "U64"
+          ]
+        },
+        {
+          "name": "new",
+          "visibility": "Friend",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "ctx",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "tx_context",
+                        "name": "TxContext"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            {
+              "Datatype": {
+                "type_name": {
+                  "address": "0xa3",
+                  "module": "priority_fee_vault",
+                  "name": "PriorityFeeVault"
+                },
+                "type_arguments": []
+              }
+            }
+          ]
+        },
+        {
+          "name": "new_deposit",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "amount",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0x2",
+                    "module": "balance",
+                    "name": "Balance"
+                  },
+                  "type_arguments": [
+                    {
+                      "Datatype": {
+                        "type_name": {
+                          "address": "0x2",
+                          "module": "sui",
+                          "name": "SUI"
+                        },
+                        "type_arguments": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "leader_cap_id",
+              "ty": "Address"
+            },
+            {
+              "name": "charged_amount",
+              "ty": "U64"
+            }
+          ],
+          "return_types": [
+            {
+              "Datatype": {
+                "type_name": {
+                  "address": "0xa3",
+                  "module": "priority_fee_vault",
+                  "name": "PriorityFeeDeposit"
+                },
+                "type_arguments": []
+              }
+            }
+          ]
+        },
+        {
+          "name": "share",
+          "visibility": "Friend",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "self",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0xa3",
+                    "module": "priority_fee_vault",
+                    "name": "PriorityFeeVault"
+                  },
+                  "type_arguments": []
+                }
+              }
+            }
+          ],
+          "return_types": []
+        },
+        {
+          "name": "withdraw",
+          "visibility": "Private",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "self",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_cap_id",
+              "ty": "Address"
+            },
+            {
+              "name": "amount",
+              "ty": "U64"
+            },
+            {
+              "name": "ctx",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "tx_context",
+                        "name": "TxContext"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            {
+              "Datatype": {
+                "type_name": {
+                  "address": "0x2",
+                  "module": "coin",
+                  "name": "Coin"
+                },
+                "type_arguments": [
+                  {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "sui",
+                        "name": "SUI"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "withdraw_priority_fee",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "self",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_cap",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa1",
+                        "module": "owner_cap",
+                        "name": "CloneableOwnerCap"
+                      },
+                      "type_arguments": [
+                        {
+                          "Datatype": {
+                            "type_name": {
+                              "address": "0xa3",
+                              "module": "leader_cap",
+                              "name": "OverNetwork"
+                            },
+                            "type_arguments": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "amount",
+              "ty": "U64"
+            },
+            {
+              "name": "ctx",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "tx_context",
+                        "name": "TxContext"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": [
+            {
+              "Datatype": {
+                "type_name": {
+                  "address": "0x2",
+                  "module": "coin",
+                  "name": "Coin"
+                },
+                "type_arguments": [
+                  {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "sui",
+                        "name": "SUI"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                ]
+              }
+            }
           ]
         }
       ]

--- a/sdk/src/move_bindings/ir/scheduler.json
+++ b/sdk/src/move_bindings/ir/scheduler.json
@@ -197,7 +197,7 @@
                   "ty": "U64"
                 },
                 {
-                  "name": "priority_fee_per_gas_unit",
+                  "name": "priority_fee_percentage",
                   "position": 4,
                   "ty": "U64"
                 },
@@ -258,7 +258,7 @@
                   }
                 },
                 {
-                  "name": "priority_fee_per_gas_unit",
+                  "name": "priority_fee_percentage",
                   "position": 2,
                   "ty": "U64"
                 },
@@ -332,7 +332,7 @@
                   }
                 },
                 {
-                  "name": "priority_fee_per_gas_unit",
+                  "name": "priority_fee_percentage",
                   "position": 3,
                   "ty": "U64"
                 },
@@ -522,7 +522,7 @@
                   }
                 },
                 {
-                  "name": "priority_fee_per_gas_unit",
+                  "name": "priority_fee_percentage",
                   "position": 7,
                   "ty": "U64"
                 }
@@ -651,7 +651,7 @@
                   }
                 },
                 {
-                  "name": "priority_fee_per_gas_unit",
+                  "name": "priority_fee_percentage",
                   "position": 5,
                   "ty": "U64"
                 },
@@ -1261,8 +1261,19 @@
               }
             },
             {
-              "name": "priority_fee_per_gas_unit",
-              "ty": "U64"
+              "name": "priority_fee_percentage",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0x1",
+                    "module": "option",
+                    "name": "Option"
+                  },
+                  "type_arguments": [
+                    "U64"
+                  ]
+                }
+              }
             },
             {
               "name": "leader_registry",
@@ -1383,8 +1394,19 @@
               }
             },
             {
-              "name": "priority_fee_per_gas_unit",
-              "ty": "U64"
+              "name": "priority_fee_percentage",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0x1",
+                    "module": "option",
+                    "name": "Option"
+                  },
+                  "type_arguments": [
+                    "U64"
+                  ]
+                }
+              }
             },
             {
               "name": "leader_registry",
@@ -1487,8 +1509,19 @@
               }
             },
             {
-              "name": "priority_fee_per_gas_unit",
-              "ty": "U64"
+              "name": "priority_fee_percentage",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0x1",
+                    "module": "option",
+                    "name": "Option"
+                  },
+                  "type_arguments": [
+                    "U64"
+                  ]
+                }
+              }
             },
             {
               "name": "leader_registry",
@@ -2523,7 +2556,7 @@
               }
             },
             {
-              "name": "priority_fee_per_gas_unit",
+              "name": "priority_fee_percentage",
               "ty": "U64"
             }
           ],
@@ -3036,7 +3069,7 @@
               }
             },
             {
-              "name": "priority_fee_per_gas_unit",
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -3488,7 +3521,7 @@
               }
             },
             {
-              "name": "priority_fee_per_gas_unit",
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -3917,11 +3950,11 @@
               }
             },
             {
-              "name": "prepay_amount",
+              "name": "prepay_amount_mist",
               "ty": "U64"
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -4144,7 +4177,7 @@
               }
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -4402,7 +4435,7 @@
               "ty": "Address"
             },
             {
-              "name": "occurrence_budget",
+              "name": "occurrence_budget_mist",
               "ty": "U64"
             },
             {
@@ -4554,8 +4587,19 @@
               }
             },
             {
-              "name": "priority_fee_per_gas_unit",
-              "ty": "U64"
+              "name": "priority_fee_percentage",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0x1",
+                    "module": "option",
+                    "name": "Option"
+                  },
+                  "type_arguments": [
+                    "U64"
+                  ]
+                }
+              }
             },
             {
               "name": "leader_registry",
@@ -5360,6 +5404,32 @@
                 "type_arguments": []
               }
             }
+          ]
+        },
+        {
+          "name": "priority_fee_percentage",
+          "visibility": "Private",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "priority_fee_percentage",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0x1",
+                    "module": "option",
+                    "name": "Option"
+                  },
+                  "type_arguments": [
+                    "U64"
+                  ]
+                }
+              }
+            }
+          ],
+          "return_types": [
+            "U64"
           ]
         },
         {

--- a/sdk/src/move_bindings/ir/workflow.json
+++ b/sdk/src/move_bindings/ir/workflow.json
@@ -419,7 +419,7 @@
                   "ty": "U64"
                 },
                 {
-                  "name": "priority_fee_per_gas_unit",
+                  "name": "priority_fee_percentage",
                   "position": 5,
                   "ty": "U64"
                 },
@@ -3054,6 +3054,24 @@
                   }
                 }
               }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
             }
           ],
           "return_types": []
@@ -3952,7 +3970,7 @@
               "ty": "Address"
             },
             {
-              "name": "priority_fee_per_gas_unit",
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -4012,7 +4030,7 @@
               }
             },
             {
-              "name": "payment_max_budget",
+              "name": "payment_max_budget_mist",
               "ty": "U64"
             },
             {
@@ -4229,7 +4247,7 @@
               "ty": "Address"
             },
             {
-              "name": "priority_fee_per_gas_unit",
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -4265,7 +4283,7 @@
               }
             },
             {
-              "name": "payment_max_budget",
+              "name": "payment_max_budget_mist",
               "ty": "U64"
             },
             {
@@ -4464,7 +4482,7 @@
               "ty": "Address"
             },
             {
-              "name": "priority_fee_per_gas_unit",
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -4492,7 +4510,7 @@
               }
             },
             {
-              "name": "payment_max_budget",
+              "name": "payment_max_budget_mist",
               "ty": "U64"
             },
             {
@@ -4726,7 +4744,7 @@
               "ty": "Address"
             },
             {
-              "name": "priority_fee_per_gas_unit",
+              "name": "priority_fee_percentage",
               "ty": "U64"
             },
             {
@@ -5105,6 +5123,42 @@
                         "address": "0xa4",
                         "module": "execution",
                         "name": "CommittedToolResult"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "priority_fee_vault",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
                       },
                       "type_arguments": []
                     }
@@ -7917,6 +7971,24 @@
                   }
                 }
               }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
             }
           ],
           "return_types": [
@@ -7940,6 +8012,24 @@
                         "address": "0xa4",
                         "module": "execution",
                         "name": "CommittedToolResult"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
                       },
                       "type_arguments": []
                     }
@@ -7996,6 +8086,24 @@
                         "address": "0xa4",
                         "module": "execution",
                         "name": "DAGExecution"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
                       },
                       "type_arguments": []
                     }
@@ -9719,6 +9827,42 @@
                         "address": "0xa3",
                         "module": "tool_registry",
                         "name": "ToolRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "priority_fee_vault",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
                       },
                       "type_arguments": []
                     }
@@ -11570,7 +11714,7 @@
               }
             },
             {
-              "name": "payment_max_budget",
+              "name": "payment_max_budget_mist",
               "ty": "U64"
             },
             {
@@ -11721,7 +11865,7 @@
               }
             },
             {
-              "name": "payment_max_budget",
+              "name": "payment_max_budget_mist",
               "ty": "U64"
             },
             {
@@ -11890,7 +12034,7 @@
               }
             },
             {
-              "name": "payment_max_budget",
+              "name": "payment_max_budget_mist",
               "ty": "U64"
             },
             {
@@ -17803,6 +17947,42 @@
               }
             },
             {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "priority_fee_vault",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
               "name": "walk_index",
               "ty": "U64"
             },
@@ -17898,6 +18078,42 @@
                         "address": "0xa3",
                         "module": "tool_registry",
                         "name": "ToolRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "priority_fee_vault",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
                       },
                       "type_arguments": []
                     }
@@ -18044,6 +18260,42 @@
                         "address": "0xa3",
                         "module": "tool_registry",
                         "name": "ToolRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "priority_fee_vault",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
                       },
                       "type_arguments": []
                     }
@@ -18225,6 +18477,24 @@
                         "address": "0xa3",
                         "module": "leader",
                         "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "priority_fee_vault",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
                       },
                       "type_arguments": []
                     }
@@ -19686,6 +19956,24 @@
                         "address": "0xa3",
                         "module": "leader",
                         "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "priority_fee_vault",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "priority_fee_vault",
+                        "name": "PriorityFeeVault"
                       },
                       "type_arguments": []
                     }

--- a/sdk/src/move_boundary/mod.rs
+++ b/sdk/src/move_boundary/mod.rs
@@ -545,6 +545,7 @@ mod tests {
             },
             gas_service: obj(6),
             leader_registry: obj(7),
+            priority_fee_vault: obj(8),
             workflow_original_pkg_id: Some(addr(0x40)),
             scheduler_original_pkg_id: Some(addr(0x50)),
         }

--- a/sdk/src/nexus/scheduler.rs
+++ b/sdk/src/nexus/scheduler.rs
@@ -73,7 +73,7 @@ pub struct CreateTaskParams {
     pub entry_group: String,
     pub input_data: HashMap<String, HashMap<String, NexusData>>,
     pub metadata: Vec<(String, String)>,
-    pub execution_priority_fee_per_gas_unit: u64,
+    pub execution_priority_fee_percentage: Option<u64>,
     pub initial_schedule: Option<OccurrenceRequest>,
     pub generator: GeneratorKind,
     /// When both `agent_id` and `skill_id` are supplied, the task is built
@@ -90,16 +90,16 @@ pub struct CreateTaskParams {
 pub enum CreateTaskTapPayment {
     /// Reserve funded from the transaction sender's SUI balance.
     UserFunded {
-        prepay_amount: u64,
+        prepay_amount_mist: u64,
         refund_recipient: Option<sui::types::Address>,
-        occurrence_budget: u64,
+        occurrence_budget_mist: u64,
         selected_dag: Option<sui::types::Address>,
         authorization_templates: Vec<AgentVertexAuthorizationTemplate>,
     },
     /// Reserve funded from the selected agent's vault.
     AgentFunded {
-        prepay_amount: u64,
-        occurrence_budget: u64,
+        prepay_amount_mist: u64,
+        occurrence_budget_mist: u64,
         selected_dag: Option<sui::types::Address>,
         authorization_templates: Vec<AgentVertexAuthorizationTemplate>,
     },
@@ -117,8 +117,8 @@ pub struct CreateTaskResult {
 pub struct CreateTaskTapPaymentResult {
     pub agent_id: AgentId,
     pub skill_id: SkillId,
-    pub prepay_amount: u64,
-    pub occurrence_budget: u64,
+    pub prepay_amount_mist: u64,
+    pub occurrence_budget_mist: u64,
 }
 
 /// Result returned after enqueuing an occurrence.
@@ -134,7 +134,7 @@ pub struct OccurrenceRequest {
     pub deadline_ms: Option<u64>,
     pub start_offset_ms: Option<u64>,
     pub deadline_offset_ms: Option<u64>,
-    pub priority_fee_per_gas_unit: u64,
+    pub priority_fee_percentage: Option<u64>,
 }
 
 impl OccurrenceRequest {
@@ -143,7 +143,7 @@ impl OccurrenceRequest {
         deadline_ms: Option<u64>,
         start_offset_ms: Option<u64>,
         deadline_offset_ms: Option<u64>,
-        priority_fee_per_gas_unit: u64,
+        priority_fee_percentage: Option<u64>,
         require_start: bool,
     ) -> Result<Self, NexusError> {
         validate_schedule_options(
@@ -159,7 +159,7 @@ impl OccurrenceRequest {
             deadline_ms,
             start_offset_ms,
             deadline_offset_ms,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
         })
     }
 }
@@ -178,7 +178,7 @@ pub struct PeriodicScheduleConfig {
     pub period_ms: u64,
     pub deadline_offset_ms: Option<u64>,
     pub max_iterations: Option<u64>,
-    pub priority_fee_per_gas_unit: u64,
+    pub priority_fee_percentage: Option<u64>,
 }
 
 pub struct PeriodicScheduleResult {
@@ -211,8 +211,8 @@ fn create_task_payment_result(
 
     match tap_payment {
         CreateTaskTapPayment::UserFunded {
-            prepay_amount,
-            occurrence_budget,
+            prepay_amount_mist,
+            occurrence_budget_mist,
             ..
         } => {
             let (agent_id, skill_id) = agent_binding.unwrap_or((
@@ -223,13 +223,13 @@ fn create_task_payment_result(
             Ok(Some(CreateTaskTapPaymentResult {
                 agent_id,
                 skill_id,
-                prepay_amount: *prepay_amount,
-                occurrence_budget: *occurrence_budget,
+                prepay_amount_mist: *prepay_amount_mist,
+                occurrence_budget_mist: *occurrence_budget_mist,
             }))
         }
         CreateTaskTapPayment::AgentFunded {
-            prepay_amount,
-            occurrence_budget,
+            prepay_amount_mist,
+            occurrence_budget_mist,
             ..
         } => {
             let Some((agent_id, skill_id)) = agent_binding else {
@@ -242,8 +242,8 @@ fn create_task_payment_result(
             Ok(Some(CreateTaskTapPaymentResult {
                 agent_id,
                 skill_id,
-                prepay_amount: *prepay_amount,
-                occurrence_budget: *occurrence_budget,
+                prepay_amount_mist: *prepay_amount_mist,
+                occurrence_budget_mist: *occurrence_budget_mist,
             }))
         }
     }
@@ -260,7 +260,7 @@ impl SchedulerActions {
             entry_group,
             input_data,
             metadata,
-            execution_priority_fee_per_gas_unit,
+            execution_priority_fee_percentage,
             initial_schedule: initial_schedule_request,
             generator,
             agent_id,
@@ -284,26 +284,26 @@ impl SchedulerActions {
         if let Some((agent_id, skill_id)) = agent_binding {
             let payment = match tap_payment {
                 Some(CreateTaskTapPayment::UserFunded {
-                    prepay_amount,
+                    prepay_amount_mist,
                     refund_recipient,
-                    occurrence_budget,
+                    occurrence_budget_mist,
                     selected_dag,
                     authorization_templates,
                 }) => crate::nexus::tap::AgentTaskPayment::UserFunded {
-                    prepay_amount,
+                    prepay_amount_mist,
                     refund_recipient,
-                    occurrence_budget,
+                    occurrence_budget_mist,
                     selected_dag,
                     authorization_templates,
                 },
                 Some(CreateTaskTapPayment::AgentFunded {
-                    prepay_amount,
-                    occurrence_budget,
+                    prepay_amount_mist,
+                    occurrence_budget_mist,
                     selected_dag,
                     authorization_templates,
                 }) => crate::nexus::tap::AgentTaskPayment::AgentVault {
-                    prepay_amount,
-                    occurrence_budget,
+                    prepay_amount_mist,
+                    occurrence_budget_mist,
                     selected_dag,
                     authorization_templates,
                 },
@@ -322,7 +322,7 @@ impl SchedulerActions {
                     entry_group,
                     input_data,
                     metadata,
-                    execution_priority_fee_per_gas_unit,
+                    execution_priority_fee_percentage,
                     initial_schedule: initial_schedule_request,
                     generator,
                     agent_id,
@@ -338,8 +338,8 @@ impl SchedulerActions {
             create_task_payment_result(&tap_payment, agent_binding, &self.client.nexus_objects)?;
 
         let Some(CreateTaskTapPayment::UserFunded {
-            prepay_amount,
-            occurrence_budget,
+            prepay_amount_mist,
+            occurrence_budget_mist,
             refund_recipient,
             selected_dag,
             authorization_templates,
@@ -365,9 +365,9 @@ impl SchedulerActions {
             &input_data,
             &metadata,
             generator.into(),
-            execution_priority_fee_per_gas_unit,
-            *prepay_amount,
-            *occurrence_budget,
+            execution_priority_fee_percentage,
+            *prepay_amount_mist,
+            *occurrence_budget_mist,
         )
         .map_err(NexusError::TransactionBuilding)?;
         let response = self.client.submit_transaction(tx, address).await?;
@@ -476,7 +476,7 @@ impl SchedulerActions {
                 period_ms: config.period_ms,
                 deadline_offset_ms: config.deadline_offset_ms,
                 max_iterations: config.max_iterations,
-                priority_fee_per_gas_unit: config.priority_fee_per_gas_unit,
+                priority_fee_percentage: config.priority_fee_percentage,
             },
         )
         .map_err(NexusError::TransactionBuilding)?;
@@ -526,7 +526,7 @@ impl SchedulerActions {
                 &task_ref,
                 start_ms,
                 deadline_offset,
-                request.priority_fee_per_gas_unit,
+                request.priority_fee_percentage,
             )
         } else {
             scheduler_tx::add_occurrence_relative_for_task_for_self_ptb(
@@ -534,7 +534,7 @@ impl SchedulerActions {
                 &task_ref,
                 request.start_offset_ms.expect("validated start offset"),
                 request.deadline_offset_ms,
-                request.priority_fee_per_gas_unit,
+                request.priority_fee_percentage,
             )
         }
         .map_err(NexusError::TransactionBuilding)?;
@@ -1155,7 +1155,7 @@ mod tests {
             entry_group: graph_move::EntryGroup::new("entry"),
             inputs: vec_map::VecMap { contents: vec![] },
             invoker: sui::types::Address::ZERO,
-            priority_fee_per_gas_unit: 0,
+            priority_fee_percentage: 0,
             authorization_templates: vec![],
         }
     }
@@ -1335,7 +1335,7 @@ mod tests {
                 }],
             },
             invoker,
-            priority_fee_per_gas_unit: 1000,
+            priority_fee_percentage: 1000,
             authorization_templates: vec![],
         };
 
@@ -1408,7 +1408,7 @@ mod tests {
             entry_group: graph_move::EntryGroup::new("entry"),
             inputs: vec_map::VecMap { contents: vec![] },
             invoker: sui::types::Address::ZERO,
-            priority_fee_per_gas_unit: 0,
+            priority_fee_percentage: 0,
             authorization_templates: vec![],
         };
 
@@ -1471,15 +1471,15 @@ mod tests {
             entry_group: "entry".into(),
             input_data: sample_input_data(),
             metadata: vec![("team".into(), "sdk".into())],
-            execution_priority_fee_per_gas_unit: 1,
+            execution_priority_fee_percentage: Some(10),
             initial_schedule: None,
             generator: GeneratorKind::Queue,
             agent_id: None,
             skill_id: None,
             tap_payment: Some(CreateTaskTapPayment::UserFunded {
-                prepay_amount: 1_000,
+                prepay_amount_mist: 1_000,
                 refund_recipient: None,
-                occurrence_budget: 100,
+                occurrence_budget_mist: 100,
                 selected_dag: None,
                 authorization_templates: vec![],
             }),
@@ -1499,8 +1499,8 @@ mod tests {
             Some(CreateTaskTapPaymentResult {
                 agent_id: nexus_objects.default_dag_executor.agent_id,
                 skill_id: nexus_objects.default_dag_executor.skill_id,
-                prepay_amount: 1_000,
-                occurrence_budget: 100,
+                prepay_amount_mist: 1_000,
+                occurrence_budget_mist: 100,
             })
         );
     }
@@ -1588,7 +1588,7 @@ mod tests {
         .await;
 
         let initial_schedule =
-            OccurrenceRequest::new(Some(1_000), Some(2_000), None, None, 5, true)
+            OccurrenceRequest::new(Some(1_000), Some(2_000), None, None, Some(50), true)
                 .expect("valid request");
 
         let params = CreateTaskParams {
@@ -1596,15 +1596,15 @@ mod tests {
             entry_group: "entry".into(),
             input_data: sample_input_data(),
             metadata: vec![],
-            execution_priority_fee_per_gas_unit: 5,
+            execution_priority_fee_percentage: Some(50),
             initial_schedule: Some(initial_schedule),
             generator: GeneratorKind::Queue,
             agent_id: None,
             skill_id: None,
             tap_payment: Some(CreateTaskTapPayment::UserFunded {
-                prepay_amount: 2_000,
+                prepay_amount_mist: 2_000,
                 refund_recipient: None,
-                occurrence_budget: 200,
+                occurrence_budget_mist: 200,
                 selected_dag: None,
                 authorization_templates: vec![],
             }),
@@ -1629,8 +1629,8 @@ mod tests {
             Some(CreateTaskTapPaymentResult {
                 agent_id: nexus_objects.default_dag_executor.agent_id,
                 skill_id: nexus_objects.default_dag_executor.skill_id,
-                prepay_amount: 2_000,
-                occurrence_budget: 200,
+                prepay_amount_mist: 2_000,
+                occurrence_budget_mist: 200,
             })
         );
     }
@@ -1656,7 +1656,7 @@ mod tests {
             entry_group: "entry".into(),
             input_data: HashMap::new(),
             metadata: vec![],
-            execution_priority_fee_per_gas_unit: 0,
+            execution_priority_fee_percentage: None,
             initial_schedule: None,
             generator: GeneratorKind::Queue,
             agent_id: None,
@@ -1733,15 +1733,15 @@ mod tests {
             entry_group: "entry".into(),
             input_data: sample_input_data(),
             metadata: vec![],
-            execution_priority_fee_per_gas_unit: 7,
+            execution_priority_fee_percentage: Some(70),
             initial_schedule: None,
             generator: GeneratorKind::Queue,
             agent_id: Some(agent_id),
             skill_id: Some(3),
             tap_payment: Some(CreateTaskTapPayment::UserFunded {
-                prepay_amount: 100,
+                prepay_amount_mist: 100,
                 refund_recipient: None,
-                occurrence_budget: 25,
+                occurrence_budget_mist: 25,
                 selected_dag: None,
                 authorization_templates: vec![],
             }),
@@ -1761,8 +1761,8 @@ mod tests {
             Some(CreateTaskTapPaymentResult {
                 agent_id,
                 skill_id: 3,
-                prepay_amount: 100,
-                occurrence_budget: 25,
+                prepay_amount_mist: 100,
+                occurrence_budget_mist: 25,
             })
         );
     }
@@ -1795,7 +1795,7 @@ mod tests {
             entry_group: "entry".into(),
             input_data: HashMap::new(),
             metadata: vec![],
-            execution_priority_fee_per_gas_unit: 0,
+            execution_priority_fee_percentage: None,
             initial_schedule: None,
             generator: GeneratorKind::Queue,
             agent_id: Some(sui::types::Address::generate(&mut rng)),
@@ -1814,7 +1814,7 @@ mod tests {
             entry_group: "entry".into(),
             input_data: HashMap::new(),
             metadata: vec![],
-            execution_priority_fee_per_gas_unit: 0,
+            execution_priority_fee_percentage: None,
             initial_schedule: None,
             generator: GeneratorKind::Queue,
             agent_id: None,
@@ -1985,7 +1985,7 @@ mod tests {
         .await;
 
         let request =
-            OccurrenceRequest::new(Some(2_000), Some(2_500), None, None, 7, true).unwrap();
+            OccurrenceRequest::new(Some(2_000), Some(2_500), None, None, Some(70), true).unwrap();
 
         let result = nexus_client
             .scheduler()
@@ -2051,8 +2051,8 @@ mod tests {
         )
         .await;
 
-        let request =
-            OccurrenceRequest::new(None, None, Some(500), Some(900), 4, true).expect("valid");
+        let request = OccurrenceRequest::new(None, None, Some(500), Some(900), Some(40), true)
+            .expect("valid");
 
         let result = nexus_client
             .scheduler()
@@ -2112,7 +2112,7 @@ mod tests {
             period_ms: 5_000,
             deadline_offset_ms: Some(1_000),
             max_iterations: Some(5),
-            priority_fee_per_gas_unit: 20,
+            priority_fee_percentage: Some(20),
         };
 
         let result = nexus_client
@@ -2177,16 +2177,16 @@ mod tests {
 
     #[test]
     fn test_occurrence_request_validation_rules() {
-        assert!(OccurrenceRequest::new(Some(10), Some(20), None, None, 1, true).is_ok());
-        assert!(OccurrenceRequest::new(None, None, Some(5), Some(15), 1, true).is_ok());
+        assert!(OccurrenceRequest::new(Some(10), Some(20), None, None, None, true).is_ok());
+        assert!(OccurrenceRequest::new(None, None, Some(5), Some(15), None, true).is_ok());
 
-        let err = OccurrenceRequest::new(None, None, None, None, 1, true).unwrap_err();
+        let err = OccurrenceRequest::new(None, None, None, None, None, true).unwrap_err();
         assert!(matches!(err, NexusError::Configuration(msg) if msg.contains("Provide either")));
 
-        let err = OccurrenceRequest::new(Some(50), Some(40), None, None, 1, true).unwrap_err();
+        let err = OccurrenceRequest::new(Some(50), Some(40), None, None, None, true).unwrap_err();
         assert!(matches!(err, NexusError::Configuration(msg) if msg.contains("Deadline")));
 
-        let err = OccurrenceRequest::new(None, None, None, Some(10), 1, false).unwrap_err();
+        let err = OccurrenceRequest::new(None, None, None, Some(10), None, false).unwrap_err();
         assert!(matches!(err, NexusError::Configuration(msg) if msg.contains("Deadline flags")));
     }
 

--- a/sdk/src/nexus/tap.rs
+++ b/sdk/src/nexus/tap.rs
@@ -136,7 +136,7 @@ pub struct CreateAgentTaskParams {
     pub entry_group: String,
     pub input_data: HashMap<String, HashMap<String, NexusData>>,
     pub metadata: Vec<(String, String)>,
-    pub execution_priority_fee_per_gas_unit: u64,
+    pub execution_priority_fee_percentage: Option<u64>,
     pub initial_schedule: Option<crate::nexus::scheduler::OccurrenceRequest>,
     pub generator: crate::nexus::scheduler::GeneratorKind,
     pub agent_id: AgentId,
@@ -163,15 +163,15 @@ pub struct SetAgentTaskStateResult {
 #[derive(Clone, Debug)]
 pub enum AgentTaskPayment {
     UserFunded {
-        prepay_amount: u64,
+        prepay_amount_mist: u64,
         refund_recipient: Option<sui::types::Address>,
-        occurrence_budget: u64,
+        occurrence_budget_mist: u64,
         selected_dag: Option<sui::types::Address>,
         authorization_templates: Vec<AgentVertexAuthorizationTemplate>,
     },
     AgentVault {
-        prepay_amount: u64,
-        occurrence_budget: u64,
+        prepay_amount_mist: u64,
+        occurrence_budget_mist: u64,
         selected_dag: Option<sui::types::Address>,
         authorization_templates: Vec<AgentVertexAuthorizationTemplate>,
     },
@@ -705,7 +705,7 @@ impl TapActions {
             entry_group,
             input_data,
             metadata,
-            execution_priority_fee_per_gas_unit,
+            execution_priority_fee_percentage,
             initial_schedule: initial_schedule_request,
             generator,
             agent_id,
@@ -733,40 +733,40 @@ impl TapActions {
         let agent =
             agent_input_from_metadata(&agent_ref).map_err(NexusError::TransactionBuilding)?;
 
-        let (prepay_amount, occurrence_budget) = match &payment {
+        let (prepay_amount_mist, occurrence_budget_mist) = match &payment {
             AgentTaskPayment::UserFunded {
-                prepay_amount,
-                occurrence_budget,
+                prepay_amount_mist,
+                occurrence_budget_mist,
                 ..
-            } => (*prepay_amount, *occurrence_budget),
+            } => (*prepay_amount_mist, *occurrence_budget_mist),
             AgentTaskPayment::AgentVault {
-                prepay_amount,
-                occurrence_budget,
+                prepay_amount_mist,
+                occurrence_budget_mist,
                 ..
-            } => (*prepay_amount, *occurrence_budget),
+            } => (*prepay_amount_mist, *occurrence_budget_mist),
         };
         let payment_input = match &payment {
             AgentTaskPayment::UserFunded {
-                prepay_amount,
+                prepay_amount_mist,
                 refund_recipient,
-                occurrence_budget,
+                occurrence_budget_mist,
                 selected_dag,
                 authorization_templates,
             } => tap_tx::AgentTaskPaymentPtbInput::UserFunded {
-                prepay_amount: *prepay_amount,
+                prepay_amount_mist: *prepay_amount_mist,
                 refund_recipient: *refund_recipient,
-                occurrence_budget: *occurrence_budget,
+                occurrence_budget_mist: *occurrence_budget_mist,
                 selected_dag: *selected_dag,
                 authorization_templates: authorization_templates.clone(),
             },
             AgentTaskPayment::AgentVault {
-                prepay_amount,
-                occurrence_budget,
+                prepay_amount_mist,
+                occurrence_budget_mist,
                 selected_dag,
                 authorization_templates,
             } => tap_tx::AgentTaskPaymentPtbInput::AgentVault {
-                prepay_amount: *prepay_amount,
-                occurrence_budget: *occurrence_budget,
+                prepay_amount_mist: *prepay_amount_mist,
+                occurrence_budget_mist: *occurrence_budget_mist,
                 selected_dag: *selected_dag,
                 authorization_templates: authorization_templates.clone(),
             },
@@ -777,7 +777,7 @@ impl TapActions {
             address,
             &metadata,
             generator.into(),
-            execution_priority_fee_per_gas_unit,
+            execution_priority_fee_percentage,
             entry_group.as_str(),
             &input_data,
             agent_id,
@@ -813,7 +813,7 @@ impl TapActions {
                 agent_input,
                 schedule.start_offset_ms.expect("validated start offset"),
                 schedule.deadline_offset_ms,
-                schedule.priority_fee_per_gas_unit,
+                schedule.priority_fee_percentage,
             )
             .map_err(NexusError::TransactionBuilding)?;
             let schedule_response = self.client.submit_transaction(schedule_tx, address).await?;
@@ -830,8 +830,8 @@ impl TapActions {
             tap_payment: Some(crate::nexus::scheduler::CreateTaskTapPaymentResult {
                 agent_id,
                 skill_id,
-                prepay_amount,
-                occurrence_budget,
+                prepay_amount_mist,
+                occurrence_budget_mist,
             }),
         })
     }
@@ -2635,13 +2635,18 @@ mod tests {
             payment_policy:
                 crate::move_bindings::interface::payment::SkillPaymentPolicy::UserFunded,
             source_kind: PaymentSourceKind::user_funded(sui::types::Address::from_static("0x1")),
-            max_budget: 1_000_000,
-            locked_budget: 0,
+            max_budget_mist: 1_000_000,
+            gas_budget_mist: 833_334,
+            priority_fee_reserve_mist: 166_666,
+            locked_budget_mist: 0,
             funds: crate::move_bindings::sui_framework::balance::Balance {
                 value: 1_000_000,
                 phantom_t0: std::marker::PhantomData,
             },
             consumed: 0,
+            tool_fee_charged: 0,
+            priority_fee_charged: 0,
+            priority_fee_percentage: 20,
             tool_cost_snapshot: crate::move_bindings::sui_framework::vec_map::VecMap {
                 contents: vec![],
             },
@@ -2665,16 +2670,21 @@ mod tests {
             interface_revision: InterfaceVersion::new(1),
             payment_policy:
                 crate::move_bindings::interface::payment::SkillPaymentPolicy::AgentFunded {
-                    max_budget: 100,
+                    max_budget_mist: 100,
                 },
             source_kind: PaymentSourceKind::agent_funded(agent_id),
-            max_budget: 100,
-            locked_budget: 0,
+            max_budget_mist: 100,
+            gas_budget_mist: 84,
+            priority_fee_reserve_mist: 16,
+            locked_budget_mist: 0,
             funds: crate::move_bindings::sui_framework::balance::Balance {
                 value: 100,
                 phantom_t0: std::marker::PhantomData,
             },
             consumed: 0,
+            tool_fee_charged: 0,
+            priority_fee_charged: 0,
+            priority_fee_percentage: 20,
             accomplished: false,
             refunded: false,
             final_state: ExecutionPaymentFinalState::Pending,
@@ -2687,7 +2697,7 @@ mod tests {
         assert_eq!(
             payment.payment_policy,
             crate::move_bindings::interface::payment::SkillPaymentPolicy::AgentFunded {
-                max_budget: 100
+                max_budget_mist: 100
             }
         );
         assert_eq!(

--- a/sdk/src/nexus/workflow.rs
+++ b/sdk/src/nexus/workflow.rs
@@ -9,12 +9,14 @@ use crate::{
     move_bindings::interface::{agent::SkillDagBinding, graph::InputPort},
     types::{
         payment_source_from_address,
+        quote_priority_payment_budget,
         resolve_active_tap_skill_execution_target,
         resolve_default_tap_dag_executor,
         validate_execution_payment_options,
         AgentId,
         AgentRegistrySnapshot,
         DefaultDagExecutorRecord,
+        PriorityPaymentBudgetInput,
         SkillId,
         SkillRevisionLookupKey,
         DEFAULT_ENTRY_GROUP,
@@ -90,7 +92,7 @@ pub struct TapExecutionSubmitMetadata {
     pub skill_id: SkillId,
     pub dag_id: sui::types::Address,
     pub skill_revision_key: SkillRevisionLookupKey,
-    pub payment_max_budget: u64,
+    pub payment_max_budget_mist: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -371,7 +373,33 @@ pub struct AgentDagExecuteOptions {
     pub payment_source: Vec<u8>,
     pub payment_coin: Option<sui::types::ObjectReference>,
     pub payment_coin_balance: Option<u64>,
-    pub payment_max_budget: u64,
+    pub payment_max_budget_mist: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ResolvedAgentDagPaymentBudget {
+    payment_max_budget_mist: u64,
+}
+
+fn resolve_agent_dag_payment_budget(
+    options: &AgentDagExecuteOptions,
+    priority_fee_percentage: Option<u64>,
+) -> anyhow::Result<ResolvedAgentDagPaymentBudget> {
+    let quote = quote_priority_payment_budget(PriorityPaymentBudgetInput {
+        max_budget_mist: options.payment_max_budget_mist,
+        priority_fee_percentage,
+        gas_budget_mist: None,
+    })?;
+    if quote.gas_budget_mist == 0 {
+        return Err(anyhow!(
+            "TAP execution payment max budget {} MIST cannot fund a nonzero gas budget",
+            options.payment_max_budget_mist
+        ));
+    }
+
+    Ok(ResolvedAgentDagPaymentBudget {
+        payment_max_budget_mist: options.payment_max_budget_mist,
+    })
 }
 
 #[cfg(feature = "walrus")]
@@ -427,8 +455,8 @@ pub struct InspectExecutionCompletionResult {
 
 pub struct ExecutionCostResult {
     pub payment_id: sui::types::Address,
-    pub max_budget: u64,
-    pub locked_budget: u64,
+    pub max_budget_mist: u64,
+    pub locked_budget_mist: u64,
     pub consumed: u64,
     pub outstanding_locks: u64,
     pub accomplished: bool,
@@ -1125,8 +1153,7 @@ impl WorkflowActions {
     /// `storage_conf` can accept [`StorageConf::default`] if no remote storage
     /// is expected.
     ///
-    /// `priority_fee_per_gas_unit` is the per-transaction priority fee to pass
-    /// down to the DAG execution.
+    /// `priority_fee_percentage` is normalized to the effective priority fee used by payment setup.
     ///
     /// Use [`WorkflowActions::inspect_execution`] to monitor the execution.
     #[cfg(feature = "walrus")]
@@ -1134,7 +1161,7 @@ impl WorkflowActions {
         &self,
         dag_object_id: sui::types::Address,
         entry_data: HashMap<String, VecMap<InputPort, NexusData>>,
-        priority_fee_per_gas_unit: u64,
+        priority_fee_percentage: Option<u64>,
         entry_group: Option<&str>,
         storage_conf: &StorageConf,
     ) -> Result<ExecuteResult, NexusError> {
@@ -1142,7 +1169,7 @@ impl WorkflowActions {
         self.execute_default_agent_dag(
             dag_object_id,
             entry_data,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             entry_group,
             storage_conf,
             AgentDagExecuteOptions {
@@ -1150,7 +1177,7 @@ impl WorkflowActions {
                     .map_err(NexusError::TransactionBuilding)?,
                 payment_coin: None,
                 payment_coin_balance: None,
-                payment_max_budget: self.client.gas.get_budget(),
+                payment_max_budget_mist: self.client.gas.get_budget(),
             },
         )
         .await
@@ -1164,7 +1191,7 @@ impl WorkflowActions {
         &self,
         dag_object_id: sui::types::Address,
         entry_data: HashMap<String, VecMap<InputPort, NexusData>>,
-        priority_fee_per_gas_unit: u64,
+        priority_fee_percentage: Option<u64>,
         entry_group: Option<&str>,
         storage_conf: &StorageConf,
         options: AgentDagExecuteOptions,
@@ -1200,19 +1227,21 @@ impl WorkflowActions {
         let default_executor = resolve_default_agent_dag_executor(nexus_objects, &registry.data)
             .map_err(NexusError::Parsing)?;
 
+        let payment_budget = resolve_agent_dag_payment_budget(&options, priority_fee_percentage)
+            .map_err(NexusError::TransactionBuilding)?;
         validate_execution_payment_options(
             default_executor.target.agent_id,
             &default_executor.skill_revision.requirements.payment_policy,
             &options.payment_source,
-            options.payment_max_budget,
+            payment_budget.payment_max_budget_mist,
             address,
         )
         .map_err(NexusError::TransactionBuilding)?;
         if let Some(balance) = options.payment_coin_balance {
-            if balance < options.payment_max_budget {
+            if balance < payment_budget.payment_max_budget_mist {
                 return Err(NexusError::TransactionBuilding(anyhow!(
                     "TAP execution payment coin balance {balance} is below requested budget {}",
-                    options.payment_max_budget
+                    payment_budget.payment_max_budget_mist
                 )));
             }
         }
@@ -1224,7 +1253,7 @@ impl WorkflowActions {
             payment_source: options.payment_source,
             payment_coin: options.payment_coin,
             payment_coin_balance: options.payment_coin_balance,
-            payment_max_budget: options.payment_max_budget,
+            payment_max_budget_mist: payment_budget.payment_max_budget_mist,
         };
 
         let transaction_input_data = input_data
@@ -1240,7 +1269,7 @@ impl WorkflowActions {
         let tx = dag::execute_default_agent_dag_ptb(
             nexus_objects,
             &dag.object_ref(),
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             entry_group.unwrap_or(DEFAULT_ENTRY_GROUP),
             &transaction_input_data,
             &agent_execution,
@@ -1299,7 +1328,7 @@ impl WorkflowActions {
                 skill_id: default_executor.target.skill_id,
                 dag_id: dag.object_id,
                 skill_revision_key: default_executor.skill_revision.key,
-                payment_max_budget: options.payment_max_budget,
+                payment_max_budget_mist: payment_budget.payment_max_budget_mist,
             }),
         })
     }
@@ -1315,7 +1344,7 @@ impl WorkflowActions {
         agent_id: AgentId,
         skill_id: SkillId,
         entry_data: HashMap<String, VecMap<InputPort, NexusData>>,
-        priority_fee_per_gas_unit: u64,
+        priority_fee_percentage: Option<u64>,
         entry_group: Option<&str>,
         storage_conf: &StorageConf,
         options: AgentDagExecuteOptions,
@@ -1366,19 +1395,21 @@ impl WorkflowActions {
             .await
             .map_err(NexusError::Rpc)?;
 
+        let payment_budget = resolve_agent_dag_payment_budget(&options, priority_fee_percentage)
+            .map_err(NexusError::TransactionBuilding)?;
         validate_execution_payment_options(
             agent_id,
             &target.skill_revision.requirements.payment_policy,
             &options.payment_source,
-            options.payment_max_budget,
+            payment_budget.payment_max_budget_mist,
             address,
         )
         .map_err(NexusError::TransactionBuilding)?;
         if let Some(balance) = options.payment_coin_balance {
-            if balance < options.payment_max_budget {
+            if balance < payment_budget.payment_max_budget_mist {
                 return Err(NexusError::TransactionBuilding(anyhow!(
                     "TAP execution payment coin balance {balance} is below requested budget {}",
-                    options.payment_max_budget
+                    payment_budget.payment_max_budget_mist
                 )));
             }
         }
@@ -1390,7 +1421,7 @@ impl WorkflowActions {
             payment_source: options.payment_source,
             payment_coin: options.payment_coin,
             payment_coin_balance: options.payment_coin_balance,
-            payment_max_budget: options.payment_max_budget,
+            payment_max_budget_mist: payment_budget.payment_max_budget_mist,
         };
 
         let transaction_input_data = input_data
@@ -1409,7 +1440,7 @@ impl WorkflowActions {
             nexus_objects,
             &dag.object_ref(),
             agent_input,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             entry_group.unwrap_or(DEFAULT_ENTRY_GROUP),
             &transaction_input_data,
             &agent_execution,
@@ -1466,7 +1497,7 @@ impl WorkflowActions {
                 skill_id,
                 dag_id,
                 skill_revision_key: target.skill_revision.key,
-                payment_max_budget: options.payment_max_budget,
+                payment_max_budget_mist: payment_budget.payment_max_budget_mist,
             }),
         })
     }
@@ -1624,8 +1655,9 @@ impl WorkflowActions {
     /// discover or submit ToolGas candidates.
     ///
     /// If a double-expired active walk is blocked by a finalized on-chain
-    /// result whose required stamps are insufficient, this prepends the
-    /// self-validating broken-result cleanup call before aborting.
+    /// result whose required stamps are insufficient, this returns a local
+    /// transaction-building error because the current workflow package no
+    /// longer exposes a broken-result cleanup entrypoint.
     pub async fn abort_expired_execution(
         &self,
         dag_execution_id: sui::types::Address,
@@ -1883,6 +1915,7 @@ impl WorkflowActions {
                     let tool_registry = tx.shared_object(&objects.tool_registry, false)?;
                     let result = tx.shared_object(&result_ref, true)?;
                     let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
+                    let priority_fee_vault = tx.shared_object(&objects.priority_fee_vault, true)?;
                     let clock = tx.clock()?;
                     dag::settle_onchain_tool_result_for_walk(
                         tx,
@@ -1891,6 +1924,7 @@ impl WorkflowActions {
                         tool_registry,
                         result,
                         leader_registry,
+                        priority_fee_vault,
                         plan.walk_index,
                         &expected_vertex,
                         tool_witness_id,
@@ -2060,8 +2094,8 @@ impl ExecutionCostResult {
     fn from_payment(payment: ExecutionPayment) -> Self {
         Self {
             payment_id: payment.payment_id(),
-            max_budget: payment.max_budget,
-            locked_budget: payment.locked_budget,
+            max_budget_mist: payment.max_budget_mist,
+            locked_budget_mist: payment.locked_budget_mist,
             consumed: payment.consumed,
             outstanding_locks: payment.locks(),
             accomplished: payment.accomplished,
@@ -2345,7 +2379,7 @@ mod tests {
             entry_group: graph_move::EntryGroup::new(DEFAULT_ENTRY_GROUP),
             invoker: sui::types::Address::from_static("0x1"),
             created_at: 0,
-            priority_fee_per_gas_unit: 0,
+            priority_fee_percentage: 0,
             agent_id: object_id(sui::types::Address::from_static("0xa")),
             skill_id: 11,
             interface_version: InterfaceVersion::new(7),
@@ -3055,14 +3089,14 @@ mod tests {
             ])),
         )]);
 
-        let price_priority_fee = 0_u64;
+        let priority_fee_percentage = None;
 
         let result = client
             .workflow()
             .execute(
                 *dag_ref.object_id(),
                 entry_data,
-                price_priority_fee,
+                priority_fee_percentage,
                 None,
                 &StorageConf::default(),
             )
@@ -3072,7 +3106,7 @@ mod tests {
         assert_eq!(result.execution_object_id, execution_object_id);
         assert_eq!(result.tx_digest, tx_digest);
         let tap_execution = result.tap_execution.expect("TAP execution metadata");
-        assert_eq!(tap_execution.payment_max_budget, 1000);
+        assert_eq!(tap_execution.payment_max_budget_mist, 1000);
     }
 
     #[cfg(feature = "walrus")]
@@ -3222,11 +3256,11 @@ mod tests {
                 agent_id,
                 skill_id,
                 entry_data,
-                0,
+                None,
                 Some("custom"),
                 &StorageConf::default(),
                 AgentDagExecuteOptions {
-                    payment_max_budget: 100,
+                    payment_max_budget_mist: 100,
                     ..Default::default()
                 },
             )
@@ -3239,7 +3273,37 @@ mod tests {
         assert_eq!(metadata.agent_id, agent_id);
         assert_eq!(metadata.skill_id, skill_id);
         assert_eq!(metadata.dag_id, *dag_ref.object_id());
-        assert_eq!(metadata.payment_max_budget, 100);
+        assert_eq!(metadata.payment_max_budget_mist, 100);
+    }
+
+    #[test]
+    fn agent_dag_payment_max_budget_is_total_mist_ceiling() {
+        let budget = resolve_agent_dag_payment_budget(
+            &AgentDagExecuteOptions {
+                payment_max_budget_mist: 120,
+                ..Default::default()
+            },
+            Some(20),
+        )
+        .expect("total MIST ceiling should resolve");
+
+        assert_eq!(budget.payment_max_budget_mist, 120);
+    }
+
+    #[test]
+    fn agent_dag_payment_max_budget_requires_nonzero_gas_capacity() {
+        let error = resolve_agent_dag_payment_budget(
+            &AgentDagExecuteOptions {
+                payment_max_budget_mist: 0,
+                ..Default::default()
+            },
+            Some(20),
+        )
+        .expect_err("zero total ceiling cannot fund gas");
+
+        assert!(error
+            .to_string()
+            .contains("cannot fund a nonzero gas budget"));
     }
 
     #[tokio::test]
@@ -3755,13 +3819,18 @@ mod tests {
                     crate::move_bindings::interface::payment::PaymentSourceKind::user_funded(
                         sui::types::Address::from_static("0x1"),
                     ),
-                max_budget: 100_000,
-                locked_budget: 100_000,
+                max_budget_mist: 100_000,
+                gas_budget_mist: 83_334,
+                priority_fee_reserve_mist: 16_666,
+                locked_budget_mist: 100_000,
                 funds: crate::move_bindings::sui_framework::balance::Balance {
                     value: 58_000,
                     phantom_t0: std::marker::PhantomData,
                 },
                 consumed: 42_000,
+                tool_fee_charged: 42_000,
+                priority_fee_charged: 0,
+                priority_fee_percentage: 20,
                 accomplished: true,
                 refunded: false,
                 final_state: ExecutionPaymentFinalState::Accomplished,
@@ -3791,8 +3860,8 @@ mod tests {
             .expect("Failed to fetch execution cost");
 
         assert_eq!(result.payment_id, *payment_ref.object_id());
-        assert_eq!(result.max_budget, 100_000);
-        assert_eq!(result.locked_budget, 100_000);
+        assert_eq!(result.max_budget_mist, 100_000);
+        assert_eq!(result.locked_budget_mist, 100_000);
         assert_eq!(result.consumed, 42_000);
         assert_eq!(result.outstanding_locks, 0);
         assert!(result.accomplished);
@@ -3866,13 +3935,18 @@ mod tests {
                     crate::move_bindings::interface::payment::PaymentSourceKind::user_funded(
                         sui::types::Address::from_static("0x1"),
                     ),
-                max_budget: 100_000,
-                locked_budget: 0,
+                max_budget_mist: 100_000,
+                gas_budget_mist: 83_334,
+                priority_fee_reserve_mist: 16_666,
+                locked_budget_mist: 0,
                 funds: crate::move_bindings::sui_framework::balance::Balance {
                     value: 100_000,
                     phantom_t0: std::marker::PhantomData,
                 },
                 consumed: 0,
+                tool_fee_charged: 0,
+                priority_fee_charged: 0,
+                priority_fee_percentage: 20,
                 accomplished: false,
                 refunded: false,
                 final_state: ExecutionPaymentFinalState::Pending,
@@ -4003,13 +4077,18 @@ mod tests {
                     crate::move_bindings::interface::payment::PaymentSourceKind::user_funded(
                         sui::types::Address::from_static("0x1"),
                     ),
-                max_budget: 100_000,
-                locked_budget: 10,
+                max_budget_mist: 100_000,
+                gas_budget_mist: 83_334,
+                priority_fee_reserve_mist: 16_666,
+                locked_budget_mist: 10,
                 funds: crate::move_bindings::sui_framework::balance::Balance {
                     value: 100_000,
                     phantom_t0: std::marker::PhantomData,
                 },
                 consumed: 0,
+                tool_fee_charged: 0,
+                priority_fee_charged: 0,
+                priority_fee_percentage: 20,
                 accomplished: false,
                 refunded: false,
                 final_state: ExecutionPaymentFinalState::Pending,

--- a/sdk/src/test_utils/sui_mocks.rs
+++ b/sdk/src/test_utils/sui_mocks.rs
@@ -56,6 +56,7 @@ pub fn mock_nexus_objects() -> NexusObjects {
         },
         gas_service: mock_sui_object_ref(),
         leader_registry: mock_sui_object_ref(),
+        priority_fee_vault: mock_sui_object_ref(),
         workflow_original_pkg_id: None,
         scheduler_original_pkg_id: None,
     }

--- a/sdk/src/transactions/dag.rs
+++ b/sdk/src/transactions/dag.rs
@@ -44,6 +44,7 @@ use {
         sui,
         transactions::{agent_input::AgentInput, scheduler, tap},
         types::{
+            effective_priority_fee_percentage,
             AgentId,
             AuthenticatedOffchainRequestEvidence,
             AuthenticatedOffchainVerifierEvidence,
@@ -287,7 +288,7 @@ pub struct AgentDagExecuteInput {
     pub payment_source: Vec<u8>,
     pub payment_coin: Option<sui::types::ObjectReference>,
     pub payment_coin_balance: Option<u64>,
-    pub payment_max_budget: u64,
+    pub payment_max_budget_mist: u64,
 }
 
 /// PTB template for creating a new empty DAG.
@@ -1038,6 +1039,7 @@ pub fn consume_on_chain_tool_result_for_walk_ptb(
         let tool_registry = tx.shared_object(&objects.tool_registry, false)?;
         let result = tx.shared_object_by_id(result.0, result.1, true)?;
         let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
+        let priority_fee_vault = tx.shared_object(&objects.priority_fee_vault, true)?;
         let clock = tx.clock()?;
 
         consume_on_chain_tool_result_for_walk(
@@ -1048,6 +1050,7 @@ pub fn consume_on_chain_tool_result_for_walk_ptb(
             result,
             leader_cap,
             leader_registry,
+            priority_fee_vault,
             walk_index,
             next_vertex,
             tool_witness_id,
@@ -1628,6 +1631,7 @@ pub fn consume_on_chain_tool_result_for_walk(
     result: sui::types::Argument,
     leader_cap: sui::types::Argument,
     leader_registry: sui::types::Argument,
+    priority_fee_vault: sui::types::Argument,
     walk_index: u64,
     expected_vertex: &RuntimeVertex,
     tool_witness_id: sui::types::Address,
@@ -1650,6 +1654,7 @@ pub fn consume_on_chain_tool_result_for_walk(
             result,
             leader_cap,
             leader_registry,
+            priority_fee_vault,
             walk_index,
             expected_vertex,
             tool_witness_id,
@@ -1757,6 +1762,8 @@ fn settle_committed_tool_result_for_walk_by_leader(
     dag: sui::types::Argument,
     execution: sui::types::Argument,
     tool_registry: sui::types::Argument,
+    leader_registry: sui::types::Argument,
+    priority_fee_vault: sui::types::Argument,
     leader_cap: sui::types::Argument,
     walk_index: u64,
     commit_tx_digest: Vec<u8>,
@@ -1775,6 +1782,8 @@ fn settle_committed_tool_result_for_walk_by_leader(
             dag,
             execution,
             tool_registry,
+            leader_registry,
+            priority_fee_vault,
             leader_cap,
             walk_index,
             commit_tx_digest,
@@ -1808,6 +1817,7 @@ pub fn settle_committed_tool_result_for_walk_by_leader_ptb(
         let execution = tx.shared_object_by_id(execution.0, execution.1, true)?;
         let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
         let tool_registry = tx.shared_object(&objects.tool_registry, false)?;
+        let priority_fee_vault = tx.shared_object(&objects.priority_fee_vault, true)?;
         let clock = tx.clock()?;
 
         settle_committed_tool_result_for_walk_by_leader(
@@ -1815,6 +1825,8 @@ pub fn settle_committed_tool_result_for_walk_by_leader_ptb(
             dag,
             execution,
             tool_registry,
+            leader_registry,
+            priority_fee_vault,
             leader_cap,
             walk_index,
             commit_tx_digest,
@@ -1893,12 +1905,22 @@ pub fn settle_committed_tool_result_for_walk_for_self_ptb(
         let dag = tx.shared_object(dag, false)?;
         let execution = tx.shared_object(execution, true)?;
         let tool_registry = tx.shared_object(&objects.tool_registry, false)?;
+        let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
+        let priority_fee_vault = tx.shared_object(&objects.priority_fee_vault, true)?;
         let walk_index = tx.arg(&walk_index)?;
         let clock = tx.clock()?;
 
         tx.call_target(
             execution_settlement_binding::settle_committed_tool_result_for_walk_target,
-            vec![dag, execution, tool_registry, walk_index, clock],
+            vec![
+                dag,
+                execution,
+                tool_registry,
+                leader_registry,
+                priority_fee_vault,
+                walk_index,
+                clock,
+            ],
         )?;
         Ok(())
     })
@@ -1912,6 +1934,7 @@ pub fn settle_onchain_tool_result_for_walk(
     tool_registry: sui::types::Argument,
     result: sui::types::Argument,
     leader_registry: sui::types::Argument,
+    priority_fee_vault: sui::types::Argument,
     walk_index: u64,
     expected_vertex: &RuntimeVertex,
     tool_witness_id: sui::types::Address,
@@ -1929,6 +1952,7 @@ pub fn settle_onchain_tool_result_for_walk(
             tool_registry,
             result,
             leader_registry,
+            priority_fee_vault,
             walk_index,
             expected_vertex,
             tool_witness_id,
@@ -1955,6 +1979,7 @@ pub fn settle_onchain_tool_result_for_walk_for_self_ptb(
         let tool_registry = tx.shared_object(&objects.tool_registry, false)?;
         let result = tx.shared_object(result, true)?;
         let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
+        let priority_fee_vault = tx.shared_object(&objects.priority_fee_vault, true)?;
         let clock = tx.clock()?;
 
         settle_onchain_tool_result_for_walk(
@@ -1964,6 +1989,7 @@ pub fn settle_onchain_tool_result_for_walk_for_self_ptb(
             tool_registry,
             result,
             leader_registry,
+            priority_fee_vault,
             walk_index,
             expected_vertex,
             tool_witness_id,
@@ -2024,6 +2050,8 @@ pub(crate) fn settle_committed_tool_result_for_walk_by_leader_for_self_ptb(
         let dag = tx.shared_object(dag, false)?;
         let execution = tx.object_from_owner(execution, execution_owner, true)?;
         let tool_registry = tx.shared_object(&objects.tool_registry, false)?;
+        let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
+        let priority_fee_vault = tx.shared_object(&objects.priority_fee_vault, true)?;
         let leader_cap = tx.object_from_owner(leader_cap, leader_cap_owner, false)?;
         let walk_index = tx.arg(&walk_index)?;
         let commit_tx_digest = tx.arg(&commit_tx_digest)?;
@@ -2037,6 +2065,8 @@ pub(crate) fn settle_committed_tool_result_for_walk_by_leader_for_self_ptb(
                 dag,
                 execution,
                 tool_registry,
+                leader_registry,
+                priority_fee_vault,
                 leader_cap,
                 walk_index,
                 commit_tx_digest,
@@ -2200,7 +2230,7 @@ fn begin_user_funded_agent_execution(
     agent: sui::types::Argument,
     dag: sui::types::Argument,
     _dag_id: sui::types::Argument,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: u64,
     entry_group: &str,
     input_data: &HashMap<String, HashMap<String, NexusData>>,
     agent_execution: &AgentDagExecuteInput,
@@ -2212,7 +2242,7 @@ fn begin_user_funded_agent_execution(
     let entry_group = tx.graph_entry_group(entry_group)?;
     let with_vertex_inputs = begin_execution_inputs_arg(tx, input_data)?;
 
-    let priority_fee_per_gas_unit = tx.arg(&priority_fee_per_gas_unit)?;
+    let priority_fee_percentage = tx.arg(&priority_fee_percentage)?;
 
     let agent_id = tx.object_id(agent_execution.agent_id)?;
     let agent_config = tap::agent_execution_config_arg(
@@ -2221,13 +2251,13 @@ fn begin_user_funded_agent_execution(
         network,
         entry_group,
         with_vertex_inputs,
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
         agent_execution.skill_id,
         agent_execution.selected_dag,
         &agent_execution.authorization_templates,
     )?;
 
-    let payment_max_budget = tx.arg(&agent_execution.payment_max_budget)?;
+    let payment_max_budget_mist = tx.arg(&agent_execution.payment_max_budget_mist)?;
 
     tx.call_target(
         execution_entries_binding::begin_user_funded_agent_execution_target,
@@ -2238,7 +2268,7 @@ fn begin_user_funded_agent_execution(
             tool_registry,
             agent_config,
             payment_coin,
-            payment_max_budget,
+            payment_max_budget_mist,
             clock,
         ],
     )
@@ -2251,7 +2281,7 @@ fn begin_default_dag_execution(
     agent_registry: sui::types::Argument,
     dag: sui::types::Argument,
     dag_id: sui::types::Argument,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: u64,
     entry_group: &str,
     input_data: &HashMap<String, HashMap<String, NexusData>>,
     agent_execution: &AgentDagExecuteInput,
@@ -2263,17 +2293,17 @@ fn begin_default_dag_execution(
     let entry_group = tx.graph_entry_group(entry_group)?;
     let with_vertex_inputs = begin_execution_inputs_arg(tx, input_data)?;
 
-    let priority_fee_per_gas_unit = tx.arg(&priority_fee_per_gas_unit)?;
+    let priority_fee_percentage = tx.arg(&priority_fee_percentage)?;
     let config = tap::default_agent_execution_config_arg(
         tx,
         dag_id,
         network,
         entry_group,
         with_vertex_inputs,
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
     )?;
 
-    let payment_max_budget = tx.arg(&agent_execution.payment_max_budget)?;
+    let payment_max_budget_mist = tx.arg(&agent_execution.payment_max_budget_mist)?;
 
     tx.call_target(
         execution_entries_binding::begin_default_dag_execution_target,
@@ -2283,7 +2313,7 @@ fn begin_default_dag_execution(
             tool_registry,
             config,
             payment_coin,
-            payment_max_budget,
+            payment_max_budget_mist,
             clock,
         ],
     )
@@ -2311,7 +2341,7 @@ pub(crate) fn append_execute_agent_dag(
     tx: &mut move_boundary::NexusPtbBuilder<'_>,
     dag: &sui::types::ObjectReference,
     agent: AgentInput,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &HashMap<String, HashMap<String, NexusData>>,
     agent_execution: &AgentDagExecuteInput,
@@ -2321,7 +2351,7 @@ pub(crate) fn append_execute_agent_dag(
         tx,
         dag,
         Some(agent),
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
         entry_group,
         input_data,
         agent_execution,
@@ -2335,7 +2365,7 @@ pub(crate) fn execute_agent_dag_ptb(
     objects: &NexusObjects,
     dag: &sui::types::ObjectReference,
     agent: AgentInput,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &HashMap<String, HashMap<String, NexusData>>,
     agent_execution: &AgentDagExecuteInput,
@@ -2346,7 +2376,7 @@ pub(crate) fn execute_agent_dag_ptb(
             tx,
             dag,
             agent,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             entry_group,
             input_data,
             agent_execution,
@@ -2359,7 +2389,7 @@ pub(crate) fn execute_agent_dag_ptb(
 pub fn execute_default_agent_dag_ptb(
     objects: &NexusObjects,
     dag: &sui::types::ObjectReference,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &HashMap<String, HashMap<String, NexusData>>,
     agent_execution: &AgentDagExecuteInput,
@@ -2369,7 +2399,7 @@ pub fn execute_default_agent_dag_ptb(
         append_execute_default_agent_dag(
             tx,
             dag,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             entry_group,
             input_data,
             agent_execution,
@@ -2382,7 +2412,7 @@ pub fn execute_default_agent_dag_ptb(
 pub(crate) fn append_execute_default_agent_dag(
     tx: &mut move_boundary::NexusPtbBuilder<'_>,
     dag: &sui::types::ObjectReference,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &HashMap<String, HashMap<String, NexusData>>,
     agent_execution: &AgentDagExecuteInput,
@@ -2392,7 +2422,7 @@ pub(crate) fn append_execute_default_agent_dag(
         tx,
         dag,
         None,
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
         entry_group,
         input_data,
         agent_execution,
@@ -2406,7 +2436,7 @@ fn execute_agent_dag_internal(
     tx: &mut move_boundary::NexusPtbBuilder<'_>,
     dag: &sui::types::ObjectReference,
     agent: Option<AgentInput>,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &HashMap<String, HashMap<String, NexusData>>,
     agent_execution: &AgentDagExecuteInput,
@@ -2428,17 +2458,19 @@ fn execute_agent_dag_internal(
 
     let clock = tx.clock()?;
 
+    let priority_fee_percentage = effective_priority_fee_percentage(priority_fee_percentage)?;
+    let locked_payment_budget_mist = agent_execution.payment_max_budget_mist;
     let payment_coin = if let Some(payment_coin_ref) = agent_execution.payment_coin.as_ref() {
         let owned_payment_coin = tx.owned_object(payment_coin_ref)?;
         match agent_execution.payment_coin_balance {
-            Some(balance) if balance > agent_execution.payment_max_budget => {
-                let payment_amount = tx.arg(&agent_execution.payment_max_budget)?;
+            Some(balance) if balance > locked_payment_budget_mist => {
+                let payment_amount = tx.arg(&locked_payment_budget_mist)?;
                 tx.split_coins(owned_payment_coin, vec![payment_amount])?
             }
             _ => owned_payment_coin,
         }
     } else {
-        let payment_amount = tx.arg(&agent_execution.payment_max_budget)?;
+        let payment_amount = tx.arg(&locked_payment_budget_mist)?;
         let gas = tx.gas();
         tx.split_coins(gas, vec![payment_amount])?
     };
@@ -2450,7 +2482,7 @@ fn execute_agent_dag_internal(
             agent_registry,
             dag,
             dag_id,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             entry_group,
             input_data,
             agent_execution,
@@ -2467,7 +2499,7 @@ fn execute_agent_dag_internal(
             agent,
             dag,
             dag_id,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             entry_group,
             input_data,
             agent_execution,
@@ -2535,6 +2567,7 @@ mod tests {
             },
             gas_service: object_ref("0xd", 1, 13),
             leader_registry: object_ref("0xe", 1, 14),
+            priority_fee_vault: object_ref("0xf", 1, 15),
             workflow_original_pkg_id: None,
             scheduler_original_pkg_id: None,
         }
@@ -2557,6 +2590,44 @@ mod tests {
                     && call.function.as_str() == function
             })
             .unwrap_or_else(|| panic!("missing move call {module}::{function}"))
+    }
+
+    fn input_for_argument<'a>(
+        ptb: &'a ProgrammableTransaction,
+        argument: &sui::types::Argument,
+    ) -> &'a sui::types::Input {
+        let sui::types::Argument::Input(index) = argument else {
+            panic!("expected input argument, got {argument:?}");
+        };
+        ptb.inputs
+            .get(*index as usize)
+            .unwrap_or_else(|| panic!("missing input at index {index}"))
+    }
+
+    fn expect_shared_object_arg(
+        ptb: &ProgrammableTransaction,
+        argument: &sui::types::Argument,
+        expected: &sui::types::ObjectReference,
+        expected_mutable: bool,
+    ) {
+        let sui::types::Input::Shared(shared) = input_for_argument(ptb, argument) else {
+            panic!("expected shared object input, got {argument:?}");
+        };
+        assert_eq!(shared.object_id(), *expected.object_id());
+        assert_eq!(shared.version(), expected.version());
+        assert_eq!(shared.mutability().is_mutable(), expected_mutable);
+    }
+
+    fn expect_u64_arg(
+        ptb: &ProgrammableTransaction,
+        argument: &sui::types::Argument,
+        expected: u64,
+    ) {
+        let sui::types::Input::Pure(bytes) = input_for_argument(ptb, argument) else {
+            panic!("expected pure u64 input, got {argument:?}");
+        };
+        let actual = bcs::from_bytes::<u64>(bytes).expect("u64 pure argument should decode");
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -2595,5 +2666,170 @@ mod tests {
 
         assert!(lock_payment < execute);
         assert_eq!(execute, ptb.commands.len() - 1);
+    }
+
+    #[test]
+    fn consume_on_chain_tool_result_uses_priority_fee_vault_argument() {
+        let objects = nexus_objects();
+        let next_vertex = RuntimeVertex::plain("counter_increment");
+
+        let ptb = consume_on_chain_tool_result_for_walk_ptb(
+            &objects,
+            (addr("0x50"), 7),
+            (addr("0x60"), 8),
+            &object_ref("0x20", 1, 20),
+            &[],
+            9,
+            &next_vertex,
+            (addr("0x70"), 10),
+            addr("0x71"),
+            123,
+            45,
+            None,
+        )
+        .expect("ptb should build");
+
+        let call_index = move_call_index(
+            &ptb,
+            Some(objects.workflow_pkg_id),
+            "execution_submission",
+            "consume_on_chain_tool_result_for_walk",
+        );
+        let Command::MoveCall(call) = &ptb.commands[call_index] else {
+            panic!("expected consume call");
+        };
+
+        assert_eq!(call.arguments.len(), 13);
+        expect_shared_object_arg(&ptb, &call.arguments[5], &objects.leader_registry, false);
+        expect_shared_object_arg(&ptb, &call.arguments[6], &objects.priority_fee_vault, true);
+        expect_u64_arg(&ptb, &call.arguments[7], 9);
+        expect_u64_arg(&ptb, &call.arguments[10], 123);
+        expect_u64_arg(&ptb, &call.arguments[11], 45);
+    }
+
+    #[test]
+    fn settle_committed_tool_result_by_leader_uses_priority_fee_vault_argument() {
+        let objects = nexus_objects();
+
+        let ptb = settle_committed_tool_result_for_walk_by_leader_ptb(
+            &objects,
+            (addr("0x50"), 7),
+            (addr("0x60"), 8),
+            &object_ref("0x20", 1, 20),
+            &HashSet::new(),
+            11,
+            vec![9, 8, 7],
+            123,
+            45,
+            None,
+        )
+        .expect("ptb should build");
+
+        let call_index = move_call_index(
+            &ptb,
+            Some(objects.workflow_pkg_id),
+            "execution_settlement",
+            "settle_committed_tool_result_for_walk_by_leader",
+        );
+        let Command::MoveCall(call) = &ptb.commands[call_index] else {
+            panic!("expected settlement call");
+        };
+
+        assert_eq!(call.arguments.len(), 11);
+        expect_shared_object_arg(&ptb, &call.arguments[3], &objects.leader_registry, false);
+        expect_shared_object_arg(&ptb, &call.arguments[4], &objects.priority_fee_vault, true);
+        expect_u64_arg(&ptb, &call.arguments[6], 11);
+        expect_u64_arg(&ptb, &call.arguments[8], 123);
+        expect_u64_arg(&ptb, &call.arguments[9], 45);
+    }
+
+    #[test]
+    fn permissionless_settle_committed_tool_result_uses_priority_fee_vault_argument() {
+        let objects = nexus_objects();
+
+        let ptb = settle_committed_tool_result_for_walk_for_self_ptb(
+            &objects,
+            &object_ref("0x50", 7, 50),
+            &object_ref("0x60", 8, 60),
+            13,
+        )
+        .expect("ptb should build");
+
+        let call_index = move_call_index(
+            &ptb,
+            Some(objects.workflow_pkg_id),
+            "execution_settlement",
+            "settle_committed_tool_result_for_walk",
+        );
+        let Command::MoveCall(call) = &ptb.commands[call_index] else {
+            panic!("expected permissionless settlement call");
+        };
+
+        assert_eq!(call.arguments.len(), 7);
+        expect_shared_object_arg(&ptb, &call.arguments[3], &objects.leader_registry, false);
+        expect_shared_object_arg(&ptb, &call.arguments[4], &objects.priority_fee_vault, true);
+        expect_u64_arg(&ptb, &call.arguments[5], 13);
+    }
+
+    #[test]
+    fn settle_onchain_tool_result_uses_priority_fee_vault_argument() {
+        let objects = nexus_objects();
+        let next_vertex = RuntimeVertex::plain("counter_increment");
+
+        let ptb = settle_onchain_tool_result_for_walk_for_self_ptb(
+            &objects,
+            &object_ref("0x50", 7, 50),
+            &object_ref("0x60", 8, 60),
+            &object_ref("0x70", 9, 70),
+            15,
+            &next_vertex,
+            addr("0x71"),
+        )
+        .expect("ptb should build");
+
+        let call_index = move_call_index(
+            &ptb,
+            Some(objects.workflow_pkg_id),
+            "execution_settlement",
+            "settle_onchain_tool_result_for_walk",
+        );
+        let Command::MoveCall(call) = &ptb.commands[call_index] else {
+            panic!("expected on-chain settlement call");
+        };
+
+        assert_eq!(call.arguments.len(), 10);
+        expect_shared_object_arg(&ptb, &call.arguments[4], &objects.leader_registry, false);
+        expect_shared_object_arg(&ptb, &call.arguments[5], &objects.priority_fee_vault, true);
+        expect_u64_arg(&ptb, &call.arguments[6], 15);
+    }
+
+    #[test]
+    fn execute_default_agent_dag_rejects_invalid_explicit_priority() {
+        let objects = nexus_objects();
+        let agent_execution = AgentDagExecuteInput {
+            agent_id: addr("0xa1"),
+            skill_id: 177,
+            selected_dag: None,
+            authorization_templates: Vec::new(),
+            payment_source: Vec::new(),
+            payment_coin: None,
+            payment_coin_balance: None,
+            payment_max_budget_mist: 100,
+        };
+
+        let error = execute_default_agent_dag_ptb(
+            &objects,
+            &object_ref("0x50", 7, 50),
+            Some(crate::types::MIN_PRIORITY_FEE_PERCENTAGE - 1),
+            "group1",
+            &HashMap::new(),
+            &agent_execution,
+            &HashSet::new(),
+        )
+        .expect_err("invalid explicit priority must fail before PTB submission");
+
+        assert!(error
+            .to_string()
+            .contains("priority fee percentage must be in 10..=10000"));
     }
 }

--- a/sdk/src/transactions/gas.rs
+++ b/sdk/src/transactions/gas.rs
@@ -234,6 +234,7 @@ mod tests {
             },
             gas_service: object_ref("0xd", 1, 13),
             leader_registry: object_ref("0xe", 1, 14),
+            priority_fee_vault: object_ref("0xf", 1, 15),
             workflow_original_pkg_id: None,
             scheduler_original_pkg_id: None,
         }

--- a/sdk/src/transactions/leader.rs
+++ b/sdk/src/transactions/leader.rs
@@ -144,6 +144,7 @@ mod tests {
             },
             gas_service: object_ref("0xd", 1, 13),
             leader_registry: object_ref("0xe", 1, 14),
+            priority_fee_vault: object_ref("0xf", 1, 15),
             workflow_original_pkg_id: None,
             scheduler_original_pkg_id: None,
         }

--- a/sdk/src/transactions/scheduler.rs
+++ b/sdk/src/transactions/scheduler.rs
@@ -18,7 +18,7 @@ use {
         move_boundary,
         sui,
         transactions::{self, agent_input::AgentInput},
-        types::{AgentId, NexusObjects, SkillId},
+        types::{effective_priority_fee_percentage, AgentId, NexusObjects, SkillId},
     },
     std::collections::{HashMap, HashSet},
     sui::types::ProgrammableTransaction,
@@ -38,7 +38,14 @@ pub(crate) struct PeriodicScheduleInputs {
     pub period_ms: u64,
     pub deadline_offset_ms: Option<u64>,
     pub max_iterations: Option<u64>,
-    pub priority_fee_per_gas_unit: u64,
+    pub priority_fee_percentage: Option<u64>,
+}
+
+fn move_priority_fee_percentage(
+    priority_fee_percentage: Option<u64>,
+) -> anyhow::Result<MoveOption<u64>> {
+    effective_priority_fee_percentage(priority_fee_percentage)?;
+    Ok(MoveOption::from_option(priority_fee_percentage))
 }
 
 // Shared helper for turning a scheduled task object ref into a mutable shared argument.
@@ -99,9 +106,9 @@ pub(crate) fn new_default_agent_task(
     execution: sui::types::Argument,
     registry: sui::types::Argument,
     prepayment_coin: sui::types::Argument,
-    occurrence_budget: u64,
+    occurrence_budget_mist: u64,
 ) -> anyhow::Result<sui::types::Argument> {
-    let occurrence_budget = tx.arg(&occurrence_budget)?;
+    let occurrence_budget_mist = tx.arg(&occurrence_budget_mist)?;
     tx.call_target(
         scheduler_binding::new_default_agent_task_target,
         vec![
@@ -110,7 +117,7 @@ pub(crate) fn new_default_agent_task(
             execution,
             registry,
             prepayment_coin,
-            occurrence_budget,
+            occurrence_budget_mist,
         ],
     )
 }
@@ -123,24 +130,19 @@ pub(crate) fn create_default_agent_task_ptb(
     input_data: &HashMap<String, HashMap<String, NexusData>>,
     metadata: &[(String, String)],
     generator: OccurrenceGenerator,
-    priority_fee_per_gas_unit: u64,
-    prepay_amount: u64,
-    occurrence_budget: u64,
+    priority_fee_percentage: Option<u64>,
+    prepay_amount_mist: u64,
+    occurrence_budget_mist: u64,
 ) -> anyhow::Result<ProgrammableTransaction> {
     move_boundary::ptb(objects, |tx| {
         let metadata = new_metadata(tx, metadata.iter().cloned())?;
         let constraints = new_constraints_policy(tx, generator)?;
-        let execution = new_execution_policy(
-            tx,
-            dag_id,
-            priority_fee_per_gas_unit,
-            entry_group,
-            input_data,
-        )?;
+        let execution =
+            new_execution_policy(tx, dag_id, priority_fee_percentage, entry_group, input_data)?;
         let registry = tx.shared_object(&objects.agent_registry, true)?;
-        let prepay_amount = tx.arg(&prepay_amount)?;
+        let prepay_amount_mist = tx.arg(&prepay_amount_mist)?;
         let gas = tx.gas();
-        let prepayment_coin = tx.split_coins(gas, vec![prepay_amount])?;
+        let prepayment_coin = tx.split_coins(gas, vec![prepay_amount_mist])?;
         let task = new_default_agent_task(
             tx,
             metadata,
@@ -148,7 +150,7 @@ pub(crate) fn create_default_agent_task_ptb(
             execution,
             registry,
             prepayment_coin,
-            occurrence_budget,
+            occurrence_budget_mist,
         )?;
 
         tx.call_target(
@@ -290,7 +292,7 @@ fn register_periodic_generator(
 pub(crate) fn new_execution_policy(
     tx: &mut move_boundary::NexusPtbBuilder<'_>,
     dag_id: sui::types::Address,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &HashMap<String, HashMap<String, NexusData>>,
 ) -> anyhow::Result<sui::types::Argument> {
@@ -324,7 +326,8 @@ pub(crate) fn new_execution_policy(
 
     let dag_id_arg = tx.object_id(dag_id)?;
     let network_id_arg = tx.object_id(objects.network_id)?;
-    let priority_fee_per_gas_unit = tx.arg(&priority_fee_per_gas_unit)?;
+    let priority_fee_percentage =
+        tx.arg(&effective_priority_fee_percentage(priority_fee_percentage)?)?;
 
     let entry_group = tx.graph_entry_group(entry_group)?;
 
@@ -336,7 +339,7 @@ pub(crate) fn new_execution_policy(
         network_id_arg,
         entry_group,
         with_vertex_inputs,
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
     )?;
 
     register_begin_default_agent_execution(tx, execution, config)?;
@@ -348,7 +351,7 @@ pub(crate) fn new_execution_policy(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn new_agent_execution_policy(
     tx: &mut move_boundary::NexusPtbBuilder<'_>,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &HashMap<String, HashMap<String, NexusData>>,
     agent_id: AgentId,
@@ -386,7 +389,8 @@ pub(crate) fn new_agent_execution_policy(
 
     let agent_id_arg = tx.object_id(agent_id)?;
     let network_id_arg = tx.object_id(objects.network_id)?;
-    let priority_fee_per_gas_unit = tx.arg(&priority_fee_per_gas_unit)?;
+    let priority_fee_percentage =
+        tx.arg(&effective_priority_fee_percentage(priority_fee_percentage)?)?;
     let entry_group = tx.graph_entry_group(entry_group)?;
 
     let with_vertex_inputs = build_inputs_vec_map(tx, input_data)?;
@@ -397,7 +401,7 @@ pub(crate) fn new_agent_execution_policy(
         network_id_arg,
         entry_group,
         with_vertex_inputs,
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
         skill_id,
         selected_dag,
         &[],
@@ -553,13 +557,14 @@ pub(crate) fn add_occurrence_absolute_for_task_for_self_ptb(
     task: &sui::types::ObjectReference,
     start_time_ms: u64,
     deadline_offset_ms: Option<u64>,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
 ) -> anyhow::Result<ProgrammableTransaction> {
     move_boundary::ptb(objects, |tx| {
         let task = shared_task_arg(tx, task)?;
         let start_time_ms = tx.arg(&start_time_ms)?;
         let deadline_offset_ms = tx.arg(&MoveOption::from_option(deadline_offset_ms))?;
-        let priority_fee_per_gas_unit = tx.arg(&priority_fee_per_gas_unit)?;
+        let priority_fee_percentage =
+            tx.arg(&move_priority_fee_percentage(priority_fee_percentage)?)?;
         let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
         let clock = tx.clock()?;
         tx.call_target(
@@ -568,7 +573,7 @@ pub(crate) fn add_occurrence_absolute_for_task_for_self_ptb(
                 task,
                 start_time_ms,
                 deadline_offset_ms,
-                priority_fee_per_gas_unit,
+                priority_fee_percentage,
                 leader_registry,
                 clock,
             ],
@@ -583,13 +588,14 @@ pub(crate) fn add_occurrence_relative_for_task_for_self_ptb(
     task: &sui::types::ObjectReference,
     start_offset_ms: u64,
     deadline_offset_ms: Option<u64>,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
 ) -> anyhow::Result<ProgrammableTransaction> {
     move_boundary::ptb(objects, |tx| {
         let task = shared_task_arg(tx, task)?;
         let start_offset_ms = tx.arg(&start_offset_ms)?;
         let deadline_offset_ms = tx.arg(&MoveOption::from_option(deadline_offset_ms))?;
-        let priority_fee_per_gas_unit = tx.arg(&priority_fee_per_gas_unit)?;
+        let priority_fee_percentage =
+            tx.arg(&move_priority_fee_percentage(priority_fee_percentage)?)?;
         let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
         let clock = tx.clock()?;
         tx.call_target(
@@ -598,7 +604,7 @@ pub(crate) fn add_occurrence_relative_for_task_for_self_ptb(
                 task,
                 start_offset_ms,
                 deadline_offset_ms,
-                priority_fee_per_gas_unit,
+                priority_fee_percentage,
                 leader_registry,
                 clock,
             ],
@@ -614,14 +620,15 @@ pub(crate) fn add_occurrence_relative_for_agent_task_for_self_ptb(
     agent: AgentInput,
     start_offset_ms: u64,
     deadline_offset_ms: Option<u64>,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
 ) -> anyhow::Result<ProgrammableTransaction> {
     move_boundary::ptb(objects, |tx| {
         let task = shared_task_arg(tx, task)?;
         let agent = agent.immutable_ptb_argument(tx)?;
         let start_offset_ms = tx.arg(&start_offset_ms)?;
         let deadline_offset_ms = tx.arg(&MoveOption::from_option(deadline_offset_ms))?;
-        let priority_fee_per_gas_unit = tx.arg(&priority_fee_per_gas_unit)?;
+        let priority_fee_percentage =
+            tx.arg(&move_priority_fee_percentage(priority_fee_percentage)?)?;
         let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
         let clock = tx.clock()?;
         tx.call_target(
@@ -631,7 +638,7 @@ pub(crate) fn add_occurrence_relative_for_agent_task_for_self_ptb(
                 agent,
                 start_offset_ms,
                 deadline_offset_ms,
-                priority_fee_per_gas_unit,
+                priority_fee_percentage,
                 leader_registry,
                 clock,
             ],
@@ -652,7 +659,9 @@ pub(crate) fn configure_periodic_for_task_for_self_ptb(
         let period_ms = tx.arg(&schedule.period_ms)?;
         let deadline_offset_ms = tx.arg(&MoveOption::from_option(schedule.deadline_offset_ms))?;
         let max_iterations = tx.arg(&MoveOption::from_option(schedule.max_iterations))?;
-        let priority_fee_per_gas_unit = tx.arg(&schedule.priority_fee_per_gas_unit)?;
+        let priority_fee_percentage = tx.arg(&move_priority_fee_percentage(
+            schedule.priority_fee_percentage,
+        )?)?;
         let leader_registry = tx.shared_object(&objects.leader_registry, false)?;
         let clock = tx.clock()?;
         tx.call_target(
@@ -663,7 +672,7 @@ pub(crate) fn configure_periodic_for_task_for_self_ptb(
                 period_ms,
                 deadline_offset_ms,
                 max_iterations,
-                priority_fee_per_gas_unit,
+                priority_fee_percentage,
                 leader_registry,
                 clock,
             ],
@@ -806,4 +815,114 @@ fn register_begin_agent_execution(
         scheduler_binding::register_begin_agent_execution_target,
         vec![policy, config],
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::test_utils::sui_mocks::{mock_nexus_objects, mock_sui_object_ref},
+        sui::types::{Argument, Command, Input, MoveCall},
+    };
+
+    fn scheduler_call<'a>(ptb: &'a ProgrammableTransaction, function: &str) -> &'a MoveCall {
+        ptb.commands
+            .iter()
+            .find_map(|command| {
+                let Command::MoveCall(call) = command else {
+                    return None;
+                };
+                (call.module.as_str() == "scheduler" && call.function.as_str() == function)
+                    .then_some(call)
+            })
+            .unwrap_or_else(|| panic!("missing scheduler::{function} call"))
+    }
+
+    fn pure_input<'a>(ptb: &'a ProgrammableTransaction, argument: &Argument) -> &'a [u8] {
+        let Argument::Input(index) = argument else {
+            panic!("expected input argument, got {argument:?}");
+        };
+        let Some(Input::Pure(bytes)) = ptb.inputs.get(*index as usize) else {
+            panic!("expected pure input at index {index}");
+        };
+        bytes
+    }
+
+    fn assert_priority_option(
+        ptb: &ProgrammableTransaction,
+        argument: &Argument,
+        expected: Option<u64>,
+    ) {
+        let expected = bcs::to_bytes(&MoveOption::from_option(expected))
+            .expect("Move priority option should serialize");
+        assert_eq!(pure_input(ptb, argument), expected);
+    }
+
+    #[test]
+    fn queue_occurrence_encodes_explicit_priority_as_move_option() {
+        let objects = mock_nexus_objects();
+        let ptb = add_occurrence_absolute_for_task_for_self_ptb(
+            &objects,
+            &mock_sui_object_ref(),
+            1_000,
+            Some(5_000),
+            Some(77),
+        )
+        .expect("queue occurrence PTB should build");
+
+        let call = scheduler_call(&ptb, "add_occurrence_absolute_for_task");
+        assert_priority_option(&ptb, &call.arguments[3], Some(77));
+    }
+
+    #[test]
+    fn queue_occurrence_encodes_omitted_priority_as_move_none() {
+        let objects = mock_nexus_objects();
+        let ptb = add_occurrence_absolute_for_task_for_self_ptb(
+            &objects,
+            &mock_sui_object_ref(),
+            1_000,
+            None,
+            None,
+        )
+        .expect("queue occurrence PTB should build");
+
+        let call = scheduler_call(&ptb, "add_occurrence_absolute_for_task");
+        assert_priority_option(&ptb, &call.arguments[3], None);
+    }
+
+    #[test]
+    fn periodic_schedule_encodes_explicit_priority_as_move_option() {
+        let objects = mock_nexus_objects();
+        let ptb = configure_periodic_for_task_for_self_ptb(
+            &objects,
+            &mock_sui_object_ref(),
+            PeriodicScheduleInputs {
+                first_start_ms: 1_000,
+                period_ms: 500,
+                deadline_offset_ms: None,
+                max_iterations: Some(2),
+                priority_fee_percentage: Some(88),
+            },
+        )
+        .expect("periodic schedule PTB should build");
+
+        let call = scheduler_call(&ptb, "new_or_modify_periodic_for_task");
+        assert_priority_option(&ptb, &call.arguments[5], Some(88));
+    }
+
+    #[test]
+    fn scheduler_occurrence_rejects_invalid_explicit_priority() {
+        let error = add_occurrence_absolute_for_task_for_self_ptb(
+            &mock_nexus_objects(),
+            &mock_sui_object_ref(),
+            1_000,
+            None,
+            Some(crate::types::MIN_PRIORITY_FEE_PERCENTAGE - 1),
+        )
+        .expect_err("invalid explicit priority must fail before PTB submission");
+
+        assert!(error
+            .to_string()
+            .contains("priority fee percentage must be in 10..=10000"));
+    }
 }

--- a/sdk/src/transactions/tap.rs
+++ b/sdk/src/transactions/tap.rs
@@ -15,7 +15,13 @@ use {
         move_boundary,
         sui,
         transactions::{agent_input::AgentInput, scheduler::OccurrenceGenerator},
-        types::{AgentId, NexusObjects, SkillId, TapPublishArtifact},
+        types::{
+            effective_priority_fee_percentage,
+            AgentId,
+            NexusObjects,
+            SkillId,
+            TapPublishArtifact,
+        },
     },
     sui::types::ProgrammableTransaction,
 };
@@ -248,15 +254,15 @@ pub(crate) fn bind_agent_skill_ptb(
 #[derive(Clone, Debug)]
 pub(crate) enum AgentTaskPaymentPtbInput {
     UserFunded {
-        prepay_amount: u64,
+        prepay_amount_mist: u64,
         refund_recipient: Option<sui::types::Address>,
-        occurrence_budget: u64,
+        occurrence_budget_mist: u64,
         selected_dag: Option<sui::types::Address>,
         authorization_templates: Vec<AgentVertexAuthorizationTemplate>,
     },
     AgentVault {
-        prepay_amount: u64,
-        occurrence_budget: u64,
+        prepay_amount_mist: u64,
+        occurrence_budget_mist: u64,
         selected_dag: Option<sui::types::Address>,
         authorization_templates: Vec<AgentVertexAuthorizationTemplate>,
     },
@@ -268,7 +274,7 @@ pub(crate) fn create_agent_task_ptb(
     sender: sui::types::Address,
     metadata: &[(String, String)],
     generator: OccurrenceGenerator,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &std::collections::HashMap<String, std::collections::HashMap<String, NexusData>>,
     agent_id: AgentId,
@@ -286,7 +292,7 @@ pub(crate) fn create_agent_task_ptb(
         let constraints = crate::transactions::scheduler::new_constraints_policy(tx, generator)?;
         let execution = crate::transactions::scheduler::new_agent_execution_policy(
             tx,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             entry_group,
             input_data,
             agent_id,
@@ -297,16 +303,16 @@ pub(crate) fn create_agent_task_ptb(
 
         let task = match payment {
             AgentTaskPaymentPtbInput::UserFunded {
-                prepay_amount,
+                prepay_amount_mist,
                 refund_recipient,
-                occurrence_budget,
+                occurrence_budget_mist,
                 selected_dag,
                 authorization_templates,
             } => {
                 let agent = agent.clone().immutable_ptb_argument(tx)?;
-                let prepay_amount = tx.arg(prepay_amount)?;
+                let prepay_amount_mist = tx.arg(prepay_amount_mist)?;
                 let gas = tx.gas();
-                let prepayment_coin = tx.split_coins(gas, vec![prepay_amount])?;
+                let prepayment_coin = tx.split_coins(gas, vec![prepay_amount_mist])?;
                 new_invoker_funded_agent_task(
                     tx,
                     metadata,
@@ -315,20 +321,20 @@ pub(crate) fn create_agent_task_ptb(
                     registry,
                     agent,
                     agent_id,
-                    priority_fee_per_gas_unit,
+                    priority_fee_percentage,
                     entry_group,
                     input_data,
                     skill_id,
                     *selected_dag,
                     prepayment_coin,
                     refund_recipient.unwrap_or(sender),
-                    *occurrence_budget,
+                    *occurrence_budget_mist,
                     authorization_templates.clone(),
                 )?
             }
             AgentTaskPaymentPtbInput::AgentVault {
-                prepay_amount,
-                occurrence_budget,
+                prepay_amount_mist,
+                occurrence_budget_mist,
                 selected_dag,
                 authorization_templates,
             } => {
@@ -341,13 +347,13 @@ pub(crate) fn create_agent_task_ptb(
                     registry,
                     agent,
                     agent_id,
-                    priority_fee_per_gas_unit,
+                    priority_fee_percentage,
                     entry_group,
                     input_data,
                     skill_id,
                     *selected_dag,
-                    *prepay_amount,
-                    *occurrence_budget,
+                    *prepay_amount_mist,
+                    *occurrence_budget_mist,
                     authorization_templates.clone(),
                 )?
             }
@@ -371,20 +377,20 @@ pub(crate) fn new_invoker_funded_agent_task(
     registry: sui::types::Argument,
     agent: sui::types::Argument,
     agent_id: AgentId,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &std::collections::HashMap<String, std::collections::HashMap<String, NexusData>>,
     skill_id: SkillId,
     selected_dag: Option<sui::types::Address>,
     prepayment_coin: sui::types::Argument,
     refund_recipient: sui::types::Address,
-    occurrence_budget: u64,
+    occurrence_budget_mist: u64,
     authorization_templates: Vec<AgentVertexAuthorizationTemplate>,
 ) -> anyhow::Result<sui::types::Argument> {
     let agent_config = scheduled_agent_execution_config_arg(
         tx,
         agent_id,
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
         entry_group,
         input_data,
         skill_id,
@@ -392,7 +398,7 @@ pub(crate) fn new_invoker_funded_agent_task(
         &authorization_templates,
     )?;
     let refund_recipient = tx.arg(&refund_recipient)?;
-    let occurrence_budget = tx.arg(&occurrence_budget)?;
+    let occurrence_budget_mist = tx.arg(&occurrence_budget_mist)?;
     tx.call_target(
         scheduler_binding::new_invoker_funded_agent_task_target,
         vec![
@@ -404,7 +410,7 @@ pub(crate) fn new_invoker_funded_agent_task(
             agent_config,
             prepayment_coin,
             refund_recipient,
-            occurrence_budget,
+            occurrence_budget_mist,
         ],
     )
 }
@@ -419,27 +425,27 @@ pub(crate) fn new_agent_funded_task(
     registry: sui::types::Argument,
     agent: sui::types::Argument,
     agent_id: AgentId,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &std::collections::HashMap<String, std::collections::HashMap<String, NexusData>>,
     skill_id: SkillId,
     selected_dag: Option<sui::types::Address>,
-    prepay_amount: u64,
-    occurrence_budget: u64,
+    prepay_amount_mist: u64,
+    occurrence_budget_mist: u64,
     authorization_templates: Vec<AgentVertexAuthorizationTemplate>,
 ) -> anyhow::Result<sui::types::Argument> {
     let agent_config = scheduled_agent_execution_config_arg(
         tx,
         agent_id,
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
         entry_group,
         input_data,
         skill_id,
         selected_dag,
         &authorization_templates,
     )?;
-    let prepay_amount = tx.arg(&prepay_amount)?;
-    let occurrence_budget = tx.arg(&occurrence_budget)?;
+    let prepay_amount_mist = tx.arg(&prepay_amount_mist)?;
+    let occurrence_budget_mist = tx.arg(&occurrence_budget_mist)?;
     tx.call_target(
         scheduler_binding::new_agent_funded_task_target,
         vec![
@@ -449,8 +455,8 @@ pub(crate) fn new_agent_funded_task(
             registry,
             agent,
             agent_config,
-            prepay_amount,
-            occurrence_budget,
+            prepay_amount_mist,
+            occurrence_budget_mist,
         ],
     )
 }
@@ -506,11 +512,11 @@ fn payment_policy_arg(
         SkillPaymentPolicy::UserFunded => {
             tx.call_target(payment_binding::payment_policy_user_funded_target, vec![])?
         }
-        SkillPaymentPolicy::AgentFunded { max_budget } => {
-            let max_budget = tx.arg(max_budget)?;
+        SkillPaymentPolicy::AgentFunded { max_budget_mist } => {
+            let max_budget_mist = tx.arg(max_budget_mist)?;
             tx.call_target(
                 payment_binding::payment_policy_agent_funded_target,
-                vec![max_budget],
+                vec![max_budget_mist],
             )?
         }
     })
@@ -536,7 +542,7 @@ pub(crate) fn default_agent_execution_config_arg(
     network: sui::types::Argument,
     entry_group: sui::types::Argument,
     inputs: sui::types::Argument,
-    priority_fee_per_gas_unit: sui::types::Argument,
+    priority_fee_percentage: sui::types::Argument,
 ) -> anyhow::Result<sui::types::Argument> {
     tx.call_target(
         agent_binding::new_default_agent_execution_config_target,
@@ -545,7 +551,7 @@ pub(crate) fn default_agent_execution_config_arg(
             network,
             entry_group,
             inputs,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
         ],
     )
 }
@@ -557,7 +563,7 @@ pub(crate) fn agent_execution_config_arg(
     network: sui::types::Argument,
     entry_group: sui::types::Argument,
     inputs: sui::types::Argument,
-    priority_fee_per_gas_unit: sui::types::Argument,
+    priority_fee_percentage: sui::types::Argument,
     skill_id: SkillId,
     selected_dag: Option<sui::types::Address>,
     authorization_templates: &[AgentVertexAuthorizationTemplate],
@@ -574,7 +580,7 @@ pub(crate) fn agent_execution_config_arg(
             network,
             entry_group,
             inputs,
-            priority_fee_per_gas_unit,
+            priority_fee_percentage,
             skill_id,
             selected_dag,
             authorization_templates,
@@ -586,7 +592,7 @@ pub(crate) fn agent_execution_config_arg(
 fn scheduled_agent_execution_config_arg(
     tx: &mut move_boundary::NexusPtbBuilder<'_>,
     agent_id: AgentId,
-    priority_fee_per_gas_unit: u64,
+    priority_fee_percentage: Option<u64>,
     entry_group: &str,
     input_data: &std::collections::HashMap<String, std::collections::HashMap<String, NexusData>>,
     skill_id: SkillId,
@@ -598,14 +604,15 @@ fn scheduled_agent_execution_config_arg(
     let network = tx.object_id(objects.network_id)?;
     let entry_group = tx.graph_entry_group(entry_group)?;
     let inputs = crate::transactions::scheduler::build_inputs_vec_map(tx, input_data)?;
-    let priority_fee_per_gas_unit = tx.arg(&priority_fee_per_gas_unit)?;
+    let priority_fee_percentage =
+        tx.arg(&effective_priority_fee_percentage(priority_fee_percentage)?)?;
     agent_execution_config_arg(
         tx,
         agent_id,
         network,
         entry_group,
         inputs,
-        priority_fee_per_gas_unit,
+        priority_fee_percentage,
         skill_id,
         selected_dag,
         authorization_templates,

--- a/sdk/src/types/nexus_objects.rs
+++ b/sdk/src/types/nexus_objects.rs
@@ -44,6 +44,7 @@ pub struct NexusObjects {
     pub default_dag_executor: DefaultDagExecutorTarget,
     pub gas_service: sui::types::ObjectReference,
     pub leader_registry: sui::types::ObjectReference,
+    pub priority_fee_vault: sui::types::ObjectReference,
 
     /// Original (defining) package address for the workflow package.
     ///
@@ -353,6 +354,11 @@ mod tests {
                 sui::types::Digest::generate(&mut rng),
             ),
             leader_registry: sui::types::ObjectReference::new(
+                sui::types::Address::generate(&mut rng),
+                1,
+                sui::types::Digest::generate(&mut rng),
+            ),
+            priority_fee_vault: sui::types::ObjectReference::new(
                 sui::types::Address::generate(&mut rng),
                 1,
                 sui::types::Digest::generate(&mut rng),

--- a/sdk/src/types/tap.rs
+++ b/sdk/src/types/tap.rs
@@ -26,6 +26,111 @@ pub type SkillId = u64;
 pub const fn skill_id(value: u64) -> SkillId {
     value
 }
+pub const DEFAULT_PRIORITY_FEE_PERCENTAGE: u64 = 20;
+pub const MIN_PRIORITY_FEE_PERCENTAGE: u64 = 10;
+pub const MAX_PRIORITY_FEE_PERCENTAGE: u64 = 10000;
+
+/// Inputs for validating or deriving a base gas budget within a total escrow amount.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PriorityPaymentBudgetInput {
+    pub max_budget_mist: u64,
+    pub priority_fee_percentage: Option<u64>,
+    pub gas_budget_mist: Option<u64>,
+}
+
+/// Integer-only priority payment quote matching the on-chain floor arithmetic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PriorityPaymentBudgetQuote {
+    pub max_budget_mist: u64,
+    pub priority_fee_percentage: u64,
+    pub gas_budget_mist: u64,
+    pub priority_fee_reserve_mist: u64,
+    pub reserved_budget_mist: u64,
+}
+
+/// Returns the priority when it is inside the explicit on-chain range.
+pub fn normalized_priority_fee_percentage(priority_fee_percentage: u64) -> Option<u64> {
+    (MIN_PRIORITY_FEE_PERCENTAGE..=MAX_PRIORITY_FEE_PERCENTAGE)
+        .contains(&priority_fee_percentage)
+        .then_some(priority_fee_percentage)
+}
+
+/// Resolves an optional priority, defaulting omission to `20` and rejecting invalid explicit values.
+pub fn effective_priority_fee_percentage(
+    priority_fee_percentage: Option<u64>,
+) -> anyhow::Result<u64> {
+    match priority_fee_percentage {
+        None => Ok(DEFAULT_PRIORITY_FEE_PERCENTAGE),
+        Some(priority_fee_percentage) => normalized_priority_fee_percentage(priority_fee_percentage)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "priority fee percentage must be in {MIN_PRIORITY_FEE_PERCENTAGE}..={MAX_PRIORITY_FEE_PERCENTAGE}, got {priority_fee_percentage}"
+                )
+            }),
+    }
+}
+
+/// Computes `floor(gas_budget_mist * priority_fee_percentage / 100)` with widened arithmetic.
+pub fn priority_fee_mist_for_gas_budget(
+    gas_budget_mist: u64,
+    priority_fee_percentage: u64,
+) -> anyhow::Result<u64> {
+    let priority_fee_mist = u128::from(gas_budget_mist)
+        .checked_mul(u128::from(priority_fee_percentage))
+        .map(|value| value / 100)
+        .ok_or_else(|| anyhow::anyhow!("priority fee calculation overflows u128"))?;
+    u64::try_from(priority_fee_mist)
+        .map_err(|_| anyhow::anyhow!("priority fee calculation overflows u64"))
+}
+
+/// Computes the maximal gas budget satisfying `gas + floor(gas * percentage / 100) <= max`.
+pub fn gas_budget_mist_for_max_budget_mist(
+    max_budget_mist: u64,
+    priority_fee_percentage: u64,
+) -> anyhow::Result<u64> {
+    let numerator = u128::from(max_budget_mist)
+        .checked_mul(100)
+        .and_then(|value| value.checked_add(99))
+        .ok_or_else(|| anyhow::anyhow!("gas budget numerator overflows u128"))?;
+    let denominator = u128::from(priority_fee_percentage)
+        .checked_add(100)
+        .ok_or_else(|| anyhow::anyhow!("gas budget denominator overflows u128"))?;
+    u64::try_from(numerator / denominator)
+        .map_err(|_| anyhow::anyhow!("gas budget calculation overflows u64"))
+}
+
+/// Validates an explicit gas budget or derives the maximal budget for the supplied total escrow.
+pub fn quote_priority_payment_budget(
+    input: PriorityPaymentBudgetInput,
+) -> anyhow::Result<PriorityPaymentBudgetQuote> {
+    let priority_fee_percentage = effective_priority_fee_percentage(input.priority_fee_percentage)?;
+    let gas_budget_mist = match input.gas_budget_mist {
+        Some(gas_budget_mist) => gas_budget_mist,
+        None => {
+            gas_budget_mist_for_max_budget_mist(input.max_budget_mist, priority_fee_percentage)?
+        }
+    };
+
+    let priority_fee_reserve_mist =
+        priority_fee_mist_for_gas_budget(gas_budget_mist, priority_fee_percentage)?;
+    let reserved_budget_mist = gas_budget_mist
+        .checked_add(priority_fee_reserve_mist)
+        .ok_or_else(|| anyhow::anyhow!("priority payment total overflows u64"))?;
+    if reserved_budget_mist > input.max_budget_mist {
+        return Err(anyhow::anyhow!(
+            "gas budget {gas_budget_mist} MIST plus priority fee reserve {priority_fee_reserve_mist} MIST exceeds maximum budget {} MIST",
+            input.max_budget_mist
+        ));
+    }
+
+    Ok(PriorityPaymentBudgetQuote {
+        max_budget_mist: input.max_budget_mist,
+        priority_fee_percentage,
+        gas_budget_mist,
+        priority_fee_reserve_mist,
+        reserved_budget_mist,
+    })
+}
 
 /// Key for a pinned skill interface revision.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -375,7 +480,7 @@ pub fn validate_execution_payment_options(
     agent_id: AgentId,
     policy: &SkillPaymentPolicy,
     payment_source: &[u8],
-    payment_max_budget: u64,
+    payment_max_budget_mist: u64,
     payer: sui::types::Address,
 ) -> anyhow::Result<()> {
     match policy {
@@ -389,12 +494,12 @@ pub fn validate_execution_payment_options(
                 );
             }
         }
-        SkillPaymentPolicy::AgentFunded { max_budget } => {
-            if payment_max_budget == 0 || payment_max_budget > *max_budget {
+        SkillPaymentPolicy::AgentFunded { max_budget_mist } => {
+            if payment_max_budget_mist == 0 || payment_max_budget_mist > *max_budget_mist {
                 anyhow::bail!(
                     "standard TAP agent-funded payment budget {} must be positive and no greater than skill policy max {}",
-                    payment_max_budget,
-                    max_budget
+                    payment_max_budget_mist,
+                    max_budget_mist
                 );
             }
             let expected = bcs::to_bytes(&PaymentSourceKind::agent_funded(agent_id))?;
@@ -548,7 +653,9 @@ mod tests {
     fn requirements() -> SkillRequirement {
         SkillRequirement {
             input_commitment: vec![1],
-            payment_policy: SkillPaymentPolicy::AgentFunded { max_budget: 100 },
+            payment_policy: SkillPaymentPolicy::AgentFunded {
+                max_budget_mist: 100,
+            },
             schedule_policy: SkillSchedulePolicy::default(),
             fixed_tools: Vec::new(),
         }
@@ -721,7 +828,9 @@ mod tests {
         let agent_source =
             bcs::to_bytes(&PaymentSourceKind::agent_funded(agent)).expect("agent vault source");
 
-        let agent_funded = SkillPaymentPolicy::AgentFunded { max_budget: 100 };
+        let agent_funded = SkillPaymentPolicy::AgentFunded {
+            max_budget_mist: 100,
+        };
         validate_execution_payment_options(agent, &agent_funded, &agent_source, 100, payer)
             .expect("agent-funded source at policy cap");
         assert!(
@@ -820,6 +929,169 @@ mod tests {
         assert_eq!(typed.identity(), agent);
 
         assert!(bcs::from_bytes::<PaymentSourceKind>(&[9]).is_err());
+    }
+
+    #[test]
+    fn priority_budget_quote_derives_maximal_gas_with_default_percentage() {
+        let quote = quote_priority_payment_budget(PriorityPaymentBudgetInput {
+            max_budget_mist: 120,
+            priority_fee_percentage: None,
+            gas_budget_mist: None,
+        })
+        .expect("quote should fit");
+
+        assert_eq!(quote.max_budget_mist, 120);
+        assert_eq!(
+            quote.priority_fee_percentage,
+            DEFAULT_PRIORITY_FEE_PERCENTAGE
+        );
+        assert_eq!(quote.gas_budget_mist, 100);
+        assert_eq!(quote.priority_fee_reserve_mist, 20);
+        assert_eq!(quote.reserved_budget_mist, 120);
+
+        let next_reserve = priority_fee_mist_for_gas_budget(
+            quote.gas_budget_mist + 1,
+            quote.priority_fee_percentage,
+        )
+        .unwrap();
+        assert!(quote.gas_budget_mist + 1 + next_reserve > 120);
+    }
+
+    #[test]
+    fn priority_budget_quote_preserves_explicit_gas_that_exactly_consumes_ceiling() {
+        let quote = quote_priority_payment_budget(PriorityPaymentBudgetInput {
+            max_budget_mist: 10_100,
+            priority_fee_percentage: Some(MAX_PRIORITY_FEE_PERCENTAGE),
+            gas_budget_mist: Some(100),
+        })
+        .expect("quote should fit");
+
+        assert_eq!(quote.gas_budget_mist, 100);
+        assert_eq!(quote.priority_fee_reserve_mist, 10_000);
+        assert_eq!(quote.reserved_budget_mist, 10_100);
+    }
+
+    #[test]
+    fn priority_budget_quote_preserves_explicit_gas_below_ceiling() {
+        let quote = quote_priority_payment_budget(PriorityPaymentBudgetInput {
+            max_budget_mist: 121,
+            priority_fee_percentage: Some(20),
+            gas_budget_mist: Some(100),
+        })
+        .expect("quote should fit below the ceiling");
+
+        assert_eq!(quote.gas_budget_mist, 100);
+        assert_eq!(quote.priority_fee_reserve_mist, 20);
+        assert_eq!(quote.reserved_budget_mist, 120);
+    }
+
+    #[test]
+    fn priority_budget_quote_rejects_explicit_gas_above_ceiling() {
+        let error = quote_priority_payment_budget(PriorityPaymentBudgetInput {
+            max_budget_mist: 119,
+            priority_fee_percentage: Some(20),
+            gas_budget_mist: Some(100),
+        })
+        .expect_err("gas plus reserve must fit the maximum budget");
+
+        assert!(error
+            .to_string()
+            .contains("exceeds maximum budget 119 MIST"));
+    }
+
+    #[test]
+    fn priority_budget_quote_uses_default_percentage_with_explicit_gas() {
+        let quote = quote_priority_payment_budget(PriorityPaymentBudgetInput {
+            max_budget_mist: 120,
+            priority_fee_percentage: None,
+            gas_budget_mist: Some(99),
+        })
+        .expect("default percentage should validate supplied gas");
+
+        assert_eq!(
+            quote.priority_fee_percentage,
+            DEFAULT_PRIORITY_FEE_PERCENTAGE
+        );
+        assert_eq!(quote.gas_budget_mist, 99);
+        assert_eq!(quote.priority_fee_reserve_mist, 19);
+        assert_eq!(quote.reserved_budget_mist, 118);
+    }
+
+    #[test]
+    fn priority_budget_quote_derives_gas_with_explicit_percentage() {
+        let quote = quote_priority_payment_budget(PriorityPaymentBudgetInput {
+            max_budget_mist: 10_100,
+            priority_fee_percentage: Some(MAX_PRIORITY_FEE_PERCENTAGE),
+            gas_budget_mist: None,
+        })
+        .expect("explicit percentage should derive maximal gas");
+
+        assert_eq!(quote.gas_budget_mist, 100);
+        assert_eq!(quote.priority_fee_reserve_mist, 10_000);
+        assert_eq!(quote.reserved_budget_mist, 10_100);
+    }
+
+    #[test]
+    fn direct_gas_budget_formula_is_maximal_at_u64_boundary() {
+        let max_budget_mist = u64::MAX;
+        let priority_fee_percentage = MAX_PRIORITY_FEE_PERCENTAGE;
+        let gas_budget_mist =
+            gas_budget_mist_for_max_budget_mist(max_budget_mist, priority_fee_percentage)
+                .expect("widened formula should support a maximum total budget");
+        let priority_fee_reserve_mist =
+            priority_fee_mist_for_gas_budget(gas_budget_mist, priority_fee_percentage).unwrap();
+
+        assert!(
+            u128::from(gas_budget_mist) + u128::from(priority_fee_reserve_mist)
+                <= u128::from(max_budget_mist)
+        );
+        let next_gas_budget_mist = gas_budget_mist + 1;
+        let next_priority_fee_mist =
+            priority_fee_mist_for_gas_budget(next_gas_budget_mist, priority_fee_percentage)
+                .unwrap();
+        assert!(
+            u128::from(next_gas_budget_mist) + u128::from(next_priority_fee_mist)
+                > u128::from(max_budget_mist)
+        );
+    }
+
+    #[test]
+    fn priority_budget_quote_defaults_omission_and_rejects_invalid_priority() {
+        assert_eq!(
+            effective_priority_fee_percentage(None).expect("missing priority uses default"),
+            DEFAULT_PRIORITY_FEE_PERCENTAGE
+        );
+        assert_eq!(
+            effective_priority_fee_percentage(Some(MIN_PRIORITY_FEE_PERCENTAGE))
+                .expect("minimum priority is valid"),
+            MIN_PRIORITY_FEE_PERCENTAGE
+        );
+        assert_eq!(
+            effective_priority_fee_percentage(Some(MAX_PRIORITY_FEE_PERCENTAGE))
+                .expect("maximum priority is valid"),
+            MAX_PRIORITY_FEE_PERCENTAGE
+        );
+
+        let below_minimum = quote_priority_payment_budget(PriorityPaymentBudgetInput {
+            max_budget_mist: 100,
+            priority_fee_percentage: Some(9),
+            gas_budget_mist: None,
+        })
+        .expect_err("explicit priority below the on-chain minimum must fail");
+        assert!(below_minimum.to_string().contains("10..=10000"));
+
+        assert!(effective_priority_fee_percentage(Some(MAX_PRIORITY_FEE_PERCENTAGE + 1)).is_err());
+        assert_eq!(
+            normalized_priority_fee_percentage(MAX_PRIORITY_FEE_PERCENTAGE + 1),
+            None
+        );
+    }
+
+    #[test]
+    fn priority_fee_math_floors_and_rejects_overflow() {
+        assert_eq!(priority_fee_mist_for_gas_budget(9, 10).unwrap(), 0);
+        assert_eq!(priority_fee_mist_for_gas_budget(10, 10).unwrap(), 1);
+        assert!(priority_fee_mist_for_gas_budget(u64::MAX, MAX_PRIORITY_FEE_PERCENTAGE).is_err());
     }
 
     #[test]

--- a/sdk/tests/tap_contract_test.rs
+++ b/sdk/tests/tap_contract_test.rs
@@ -118,11 +118,11 @@ fn tap_payment_policy_arg(
         SkillPaymentPolicy::UserFunded => {
             tx.call_target(payment_binding::payment_policy_user_funded_target, vec![])
         }
-        SkillPaymentPolicy::AgentFunded { max_budget } => {
-            let max_budget = tx.arg(max_budget)?;
+        SkillPaymentPolicy::AgentFunded { max_budget_mist } => {
+            let max_budget_mist = tx.arg(max_budget_mist)?;
             tx.call_target(
                 payment_binding::payment_policy_agent_funded_target,
-                vec![max_budget],
+                vec![max_budget_mist],
             )
         }
     }
@@ -230,6 +230,7 @@ fn nexus_objects() -> NexusObjects {
         },
         gas_service: object_ref("0xd", 1, 13),
         leader_registry: object_ref("0xe", 1, 14),
+        priority_fee_vault: object_ref("0xf", 1, 15),
         workflow_original_pkg_id: None,
         scheduler_original_pkg_id: None,
     }
@@ -502,7 +503,9 @@ fn tap_payment_sources_validate_invoker_and_agent_vault_modes() {
     )
     .expect("user-funded payer address source validates");
 
-    let agent_funded = SkillPaymentPolicy::AgentFunded { max_budget: 100 };
+    let agent_funded = SkillPaymentPolicy::AgentFunded {
+        max_budget_mist: 100,
+    };
     assert!(
         nexus_sdk::types::validate_execution_payment_options(
             agent_id,
@@ -644,8 +647,12 @@ fn update_skill_compatibility_builds_dag_and_policy_calls() {
         let registry = tap_agent_registry_arg(tx, true).expect("configured registry");
         let agent_arg = tx.shared_object(&agent, true)?;
         let skill_id = tx.arg(&177_u64)?;
-        let payment_policy =
-            tap_payment_policy_arg(tx, &SkillPaymentPolicy::AgentFunded { max_budget: 100 })?;
+        let payment_policy = tap_payment_policy_arg(
+            tx,
+            &SkillPaymentPolicy::AgentFunded {
+                max_budget_mist: 100,
+            },
+        )?;
         let schedule_policy = tap_schedule_policy_arg(
             tx,
             &SkillSchedulePolicy {


### PR DESCRIPTION

### Nexus SDK

`nexus-sdk` now mirrors the Move contract boundary and gives callers a usable quote model:

- `NexusObjects` includes mandatory `priority_fee_vault` metadata.
- `sdk/src/types/tap.rs` exposes `PriorityPaymentBudgetInput`, `PriorityPaymentQuote`, `effective_priority_fee`, `priority_fee_for_gas`, and checked quote helpers for deriving maximum base gas cap from total escrow.
- `AgentDagExecuteInput` and high-level workflow execution options distinguish `payment_max_budget` from optional `payment_total_budget`.
- High-level workflow actions validate that total budget covers base-plus-priority escrow and split the correct total amount into the execution payment coin.
- DAG submit-result PTB helpers include `priority_fee_vault` shared object arguments in off-chain, no-verifier, registered-key, external-verifier, and on-chain submit routes.
- Gas transaction helpers include TAP payment accomplishment builders and a leader-cap-gated `withdraw_priority_fee` builder for the shared vault.
- Scheduler transaction helpers encode optional priority quotes with Move `Option<u64>` values for execution policies, occurrence additions, and periodic schedules.
- Scheduler actions validate optional priority quotes before PTB construction.
- Event and type parsers include priority-fee-aware payment fields and workflow identifiers needed by submit-result settlement.

### CLI

The CLI surfaces now use the product term for optional priority quotes:

- `nexus dag execute` accepts `--priority-fee-excess-quote`.
- `nexus tap execute` accepts `--priority-fee-excess-quote`.
- Scheduler task, occurrence, and periodic commands accept optional priority-fee excess quote flags instead of zero-default `priority-fee-per-gas-unit` arguments.
- CLI DAG execution computes a priority payment quote from total payment budget, sends the derived base gas cap on chain, and keeps the user's supplied budget as total escrow.