### PR TITLE
fix: pin Rust toolchain to 1.96.1 and bump ethnum to 1.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "eyre"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,7 @@
 [toolchain]
-channel = "stable"
+# Pinned (was "stable"): stable 1.97.0 broke the pinned `ethnum` transitive dep
+# with E0512. Keep this pinned so builds don't float onto a new stable rustc.
+channel = "1.96.1"
 components = [
     "rustc",
     "cargo",


### PR DESCRIPTION
## Problem

This repo's CI floats its Rust toolchain on `channel = "stable"` (both `rust-toolchain.toml` and the `setup-rust-toolchain` workflow inputs). Stable **1.97.0** was promoted on **Thursday 2026-07-09** and breaks the pinned `ethnum 1.5.2` transitive dep:

```
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
  --> ethnum-1.5.2/src/error.rs:16:14  ->  unsafe { mem::transmute(()) }
   = note: source `()` (0 bits) / target `TryFromIntError` (8 bits)
```

1.97.0 changed `TryFromIntError` from a 0-bit ZST to 8 bits. The last green CI runs here (10:12–10:13Z on 2026-07-09) predate 1.97.0, so they compiled on 1.96.1 — **the next compile job will pull 1.97.0 and fail.** (This is the same break that turned the `nexus-workbench` `v2.0.0-rc.4` merge red.)

## Fix — two levers (both applied)

**B. Bump `ethnum` 1.5.2 → 1.5.3** (`Cargo.lock` only). 1.5.3 removes the `transmute(())` hack (`tfie()` is no longer `const` and constructs the error safely), so it compiles on 1.97.0. **This is what unbreaks CI, on whatever rustc the workflow installs.**

**A. Pin `rust-toolchain.toml` `channel = "stable"` → `"1.96.1"`** for reproducibility, so builds don't silently float onto a new stable again. 1.96.1 is the exact version the last green build used (≥ the sui-rust-sdk MSRV floor, < the ethnum-breaking 1.97).

## Note on CI toolchain selection

The workflows call `actions-rust-lang/setup-rust-toolchain` with an explicit `toolchain: stable` (and `override: true` in `release.yml`), which can take precedence over `rust-toolchain.toml` in CI. That's fine here: **B makes the build green regardless of which rustc runs**, and A pins local/reproducible builds. If you additionally want CI to *run on* 1.96.1, change those workflow `toolchain: stable` inputs to `1.96.1` too — happy to do that in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
