### PR TITLE
fix: preserve framework binding IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Changed
 
+- Move binding regeneration now preserves the reduced Move standard library and Sui framework IR,
+  limiting deployment refreshes to Nexus packages.
 - Move binding regeneration now commits canonical SDK package identities, preventing package ID
   churn when the same Move ABI is rebound from another deployment.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,22 +90,22 @@ Sibling repos checked out next to this one (paths depend on local layout):
 ## Move binding
 
 The Move binding refresh is **not type only**. It refreshes the committed
-canonical package IR for each Nexus Move package and the fixed framework
-packages. The generated Rust surface in `sdk/src/move_bindings` is the ABI
-boundary for Move types, type tags, BCS and serde implementations, and typed
-call targets. Rust domain modules may add helpers on top, but they should not
-duplicate Move ABI logic.
+canonical package IR for each Nexus Move package. The reduced framework support
+IR remains pinned to the SDK. The generated Rust surface in
+`sdk/src/move_bindings` is the ABI boundary for Move types, type tags, BCS and
+serde implementations, and typed call targets. Rust domain modules may add
+helpers on top, but they should not duplicate Move ABI logic.
 
 How the pipeline fits together:
 
 - **Refresh half (on demand through `just sdk rebind`)**:
-  `sdk/src/bin/regenerate_bindings.rs` fetches each package's normalized IR
+  `sdk/src/bin/regenerate_bindings.rs` fetches each Nexus package's normalized IR
   through `sui_move_codegen::fetch_package`, replaces concrete Nexus package
   identities with stable SDK binding slots, normalizes the unused deployment
   version, and writes committed JSON under
-  `sdk/src/move_bindings/ir/<package>.json`. One file exists for `move_std`,
-  `sui_framework`, `primitives`, `interface`, `registry`, `workflow`, and
-  `scheduler`.
+  `sdk/src/move_bindings/ir/<package>.json`. The reduced `move_std` and
+  `sui_framework` IR files remain unchanged and are rendered alongside the five
+  refreshed Nexus package files.
 - **Offline half (every build)**: `sdk/build.rs` reads the committed IR and
   renders one `$OUT_DIR/<package>_types.rs` file per package. The rendered Rust
   includes generated Move structs, enum variants, type tags, serde and BCS
@@ -121,6 +121,8 @@ Key invariants:
 
 - Framework packages are scoped to their fixed addresses: `move_std` uses
   `0x1`, and `sui_framework` uses `0x2`.
+- Normal Nexus regeneration does not rewrite framework IR. Update that support
+  surface explicitly only when the pinned Sui version changes.
 - Committed Nexus IR uses stable binding slots: `primitives` uses `0xa1`,
   `interface` uses `0xa2`, `registry` uses `0xa3`, `workflow` uses `0xa4`, and
   `scheduler` uses `0xa5`. These slots describe the canonical SDK package
@@ -164,11 +166,11 @@ just sdk rebind \
 
 The recipe runs `sdk/src/bin/regenerate_bindings.rs` with the
 `binding_codegen` feature. The binary reads package ids from
-the supplied deployment manifest, appends the fixed framework packages
-`move_std=0x1` and `sui_framework=0x2`, fetches normalized package metadata over
-gRPC, optionally overlays trusted source parameter names, and writes the
-refreshed JSON under `sdk/src/move_bindings/ir/`. Without a source root,
-parameter names remain deterministic `argN` values. Source input does not
+the supplied deployment manifest, fetches normalized Nexus package metadata
+over gRPC, optionally overlays trusted source parameter names, and writes the
+refreshed Nexus JSON under `sdk/src/move_bindings/ir/`. The reduced `move_std`
+and `sui_framework` IR files are not fetched or rewritten. Without a source
+root, parameter names remain deterministic `argN` values. Source input does not
 replace signatures, types, or abilities from the network.
 
 Before writing, regeneration replaces every current and original Nexus package

--- a/sdk/.just
+++ b/sdk/.just
@@ -20,10 +20,11 @@ check: _check-cargo
 test: _check-cargo
     cargo +stable test --all-features --package {{ package }}
 
-# Regenerate the committed Move binding IR (src/move_bindings/ir/*.json).
+# Regenerate the committed Nexus Move binding IR (src/move_bindings/ir/*.json).
 #
 # Requires a deployment objects TOML and a running Sui gRPC endpoint.
 # Set source_root to a matching Nexus Move source tree to restore source parameter names.
+# The reduced framework support IR files remain unchanged.
 # The wrapper does not start Sui or publish packages.
 #
 # The offline render happens automatically in build.rs on the next build.

--- a/sdk/MIGRATION.md
+++ b/sdk/MIGRATION.md
@@ -199,6 +199,10 @@ Generated bindings are built from committed normalized Move package IR under
 `sdk/src/move_bindings/ir/*.json`. Normal SDK builds render Rust bindings from
 that IR through `build.rs`.
 
+Normal regeneration refreshes the five Nexus package files and preserves the reduced Move standard
+library and Sui framework support IR. Update those framework files explicitly only when the pinned
+Sui version changes.
+
 Regenerate the IR only when the published Move ABI changes:
 
 ```sh

--- a/sdk/src/bin/regenerate_bindings.rs
+++ b/sdk/src/bin/regenerate_bindings.rs
@@ -28,7 +28,6 @@ const NEXUS_PACKAGES: &[(&str, &str)] = &[
     ("workflow", "0xa4"),
     ("scheduler", "0xa5"),
 ];
-const FRAMEWORK_PACKAGES: &[(&str, &str)] = &[("move_std", "0x1"), ("sui_framework", "0x2")];
 
 #[derive(Debug, PartialEq, Eq)]
 struct Inputs {
@@ -184,10 +183,6 @@ fn packages_from_objects_toml(text: &str, source: &str) -> Result<Vec<(String, A
             .ok_or_else(|| anyhow!("{source} is missing {package}_pkg_id"))?;
         packages.push(((*package).to_string(), parse_address(id)?));
     }
-    for (package, id) in FRAMEWORK_PACKAGES {
-        packages.push(((*package).to_string(), parse_address(id)?));
-    }
-
     Ok(packages)
 }
 
@@ -221,7 +216,7 @@ mod tests {
     };
 
     #[test]
-    fn parses_required_objects_and_framework_packages() {
+    fn parses_required_nexus_packages() {
         let objects = [
             r#"primitives_pkg_id = "0x11""#,
             r#"interface_pkg_id = "0x12""#,
@@ -241,11 +236,6 @@ mod tests {
                 ("registry".to_string(), Address::from_str("0x13").unwrap()),
                 ("workflow".to_string(), Address::from_str("0x14").unwrap()),
                 ("scheduler".to_string(), Address::from_str("0x15").unwrap()),
-                ("move_std".to_string(), Address::from_str("0x1").unwrap()),
-                (
-                    "sui_framework".to_string(),
-                    Address::from_str("0x2").unwrap()
-                ),
             ]
         );
     }


### PR DESCRIPTION
## Notable changes

- Limit normal Move binding regeneration to the five Nexus deployment packages.
- Preserve the reduced Move standard library and Sui framework support IR.
- Document the framework IR lifecycle and add a package selection regression test.

## Root cause

The committed framework IR is intentionally reduced, but `regenerate_bindings` appended `0x1` and `0x2` to every deployment refresh and overwrote it with complete framework packages. That reintroduced about 52,000 unrelated JSON lines even when the Nexus ABI was unchanged.

## References

- Follow up to #508.

## Checklist

- [x] keep a changelog
- [x] write tests
- [x] create tickets for `TODO: <>` statements
- [x] create or update documentation
