### PR TITLE
feat(transactions): commit leader-authored terminal _err_eval for on-chain tool walks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Changed
 
-- Regenerated Move bindings to add `execution_submission::commit_on_chain_tool_terminal_err_eval_for_walk`, and rewrote the previously dead `PreparedOnchainToolResultSubmission::TerminalErrEval` PTB arm to call it directly instead of creating and finalizing an `OnchainToolResult` that nothing ever consumed; the variant now carries `reason: Vec<u8>` and `failure_evidence_kind: FailureEvidenceKind` and no longer creates an on-chain tool result.
+- Regenerated Move bindings to add `execution_submission::commit_on_chain_tool_terminal_err_eval_for_walk`, and rewrote the previously dead `PreparedOnchainToolResultSubmission::TerminalErrEval` PTB arm to call it directly instead of creating and finalizing an `OnchainToolResult` that nothing ever consumed; the variant now carries `reason: Vec<u8>` and `failure_evidence_kind: FailureEvidenceKind` and no longer creates an on-chain tool result. Removed the now-orphaned `PreparedOnchainToolOutput` struct, whose last consumers were removed by this same rewrite.
 - `NexusClientBuilder` now supports keyless query-only clients, while owner, gas, signing, and submission operations return a typed missing-private-key error when no signer is configured.
 - `NexusClientBuilder` can now build clients without gas for read-only use, while `NexusClient::set_gas_source` supports shared write-once transaction gas attachment after construction.
 - Replaced the Nexus specific event poller with typed Sui event queries and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 #### Changed
 
+- Regenerated Move bindings to add `execution_submission::commit_on_chain_tool_terminal_err_eval_for_walk`, and rewrote the previously dead `PreparedOnchainToolResultSubmission::TerminalErrEval` PTB arm to call it directly instead of creating and finalizing an `OnchainToolResult` that nothing ever consumed; the variant now carries `reason: Vec<u8>` and `failure_evidence_kind: FailureEvidenceKind` and no longer creates an on-chain tool result.
 - `NexusClientBuilder` now supports keyless query-only clients, while owner, gas, signing, and submission operations return a typed missing-private-key error when no signer is configured.
 - `NexusClientBuilder` can now build clients without gas for read-only use, while `NexusClient::set_gas_source` supports shared write-once transaction gas attachment after construction.
 - Replaced the Nexus specific event poller with typed Sui event queries and a

--- a/sdk/src/move_bindings/ir/registry.json
+++ b/sdk/src/move_bindings/ir/registry.json
@@ -16571,7 +16571,7 @@
           "type_parameters": [],
           "parameters": [
             {
-              "name": "_self",
+              "name": "self",
               "ty": {
                 "Ref": {
                   "mutable": false,

--- a/sdk/src/move_bindings/ir/workflow.json
+++ b/sdk/src/move_bindings/ir/workflow.json
@@ -17522,41 +17522,21 @@
               }
             },
             {
-              "name": "tool_id",
+              "name": "expected_target",
               "ty": {
                 "Datatype": {
                   "type_name": {
-                    "address": "0x2",
-                    "module": "object",
-                    "name": "ID"
+                    "address": "0xa2",
+                    "module": "verifier",
+                    "name": "LeaderTarget"
                   },
                   "type_arguments": []
                 }
               }
             },
             {
-              "name": "verifier_witness_id",
-              "ty": {
-                "Datatype": {
-                  "type_name": {
-                    "address": "0x1",
-                    "module": "option",
-                    "name": "Option"
-                  },
-                  "type_arguments": [
-                    {
-                      "Datatype": {
-                        "type_name": {
-                          "address": "0x2",
-                          "module": "object",
-                          "name": "ID"
-                        },
-                        "type_arguments": []
-                      }
-                    }
-                  ]
-                }
-              }
+              "name": "expected_stamp_count",
+              "ty": "U64"
             }
           ],
           "return_types": []
@@ -17774,6 +17754,183 @@
                     "address": "0xa2",
                     "module": "verifier",
                     "name": "VerificationVerdict"
+                  },
+                  "type_arguments": []
+                }
+              }
+            },
+            {
+              "name": "leader_cap",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa1",
+                        "module": "owner_cap",
+                        "name": "CloneableOwnerCap"
+                      },
+                      "type_arguments": [
+                        {
+                          "Datatype": {
+                            "type_name": {
+                              "address": "0xa3",
+                              "module": "leader_cap",
+                              "name": "OverNetwork"
+                            },
+                            "type_arguments": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "leader_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "leader",
+                        "name": "LeaderRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "walk_index",
+              "ty": "U64"
+            },
+            {
+              "name": "expected_vertex",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0xa2",
+                    "module": "graph",
+                    "name": "RuntimeVertex"
+                  },
+                  "type_arguments": []
+                }
+              }
+            },
+            {
+              "name": "ctx",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0x2",
+                        "module": "tx_context",
+                        "name": "TxContext"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "return_types": []
+        },
+        {
+          "name": "commit_on_chain_tool_terminal_err_eval_for_walk",
+          "visibility": "Public",
+          "is_entry": false,
+          "type_parameters": [],
+          "parameters": [
+            {
+              "name": "dag",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa2",
+                        "module": "dag",
+                        "name": "DAG"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "execution",
+              "ty": {
+                "Ref": {
+                  "mutable": true,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa4",
+                        "module": "execution",
+                        "name": "DAGExecution"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "tool_registry",
+              "ty": {
+                "Ref": {
+                  "mutable": false,
+                  "inner": {
+                    "Datatype": {
+                      "type_name": {
+                        "address": "0xa3",
+                        "module": "tool_registry",
+                        "name": "ToolRegistry"
+                      },
+                      "type_arguments": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "worksheet",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0xa1",
+                    "module": "proof_of_uid",
+                    "name": "ProofOfUID"
+                  },
+                  "type_arguments": []
+                }
+              }
+            },
+            {
+              "name": "reason",
+              "ty": {
+                "Vector": "U8"
+              }
+            },
+            {
+              "name": "failure_evidence_kind",
+              "ty": {
+                "Datatype": {
+                  "type_name": {
+                    "address": "0xa2",
+                    "module": "verifier",
+                    "name": "FailureEvidenceKind"
                   },
                   "type_arguments": []
                 }

--- a/sdk/src/transactions/dag.rs
+++ b/sdk/src/transactions/dag.rs
@@ -10,13 +10,14 @@ use {
                     RuntimeVertex,
                     Vertex as GraphVertex,
                 },
-                verifier::{FailureEvidenceKind, RegisteredKeyAuxiliary, ToolVerifierMode},
+                verifier::{
+                    self as verifier_binding,
+                    FailureEvidenceKind,
+                    RegisteredKeyAuxiliary,
+                    ToolVerifierMode,
+                },
             },
-            primitives::{
-                data::{self as data_binding, NexusData},
-                onchain_tool_result as onchain_tool_result_binding,
-                tagged_output::{self as tagged_output_binding, TaggedOutput},
-            },
+            primitives::{data::NexusData, tagged_output::TaggedOutput},
             registry::{
                 registered_key_verifier as registered_key_verifier_binding,
                 tool_registry as tool_registry_binding,
@@ -53,9 +54,6 @@ use {
     std::collections::{HashMap, HashSet},
     sui::types::ProgrammableTransaction,
 };
-
-const TERMINAL_ERR_EVAL_VARIANT: &str = "_err_eval";
-const TERMINAL_ERR_EVAL_REASON_PORT: &str = "reason";
 
 fn vertex_kind_arg(
     tx: &mut move_boundary::NexusPtbBuilder<'_>,
@@ -127,15 +125,6 @@ fn begin_execution_inputs_arg(
 pub struct PreparedOnchainToolOutput {
     pub output_variant: String,
     pub output_ports_data: HashMap<String, NexusData>,
-}
-
-impl PreparedOnchainToolOutput {
-    pub fn terminal_err_eval(reason: NexusData) -> Self {
-        Self {
-            output_variant: TERMINAL_ERR_EVAL_VARIANT.to_string(),
-            output_ports_data: HashMap::from([(TERMINAL_ERR_EVAL_REASON_PORT.to_string(), reason)]),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -219,10 +208,12 @@ pub struct PreparedOnchainToolExecution {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PreparedOnchainToolResultSubmission {
     Execute(PreparedOnchainToolExecution),
+    /// Leader-authored terminal `_err_eval` commit for a walk whose on-chain tool cannot
+    /// execute. Commits directly through `commit_on_chain_tool_terminal_err_eval_for_walk`,
+    /// creating no `OnchainToolResult` (unlike `Execute`, which runs the tool).
     TerminalErrEval {
-        output: PreparedOnchainToolOutput,
+        reason: Vec<u8>,
         failure_evidence_kind: FailureEvidenceKind,
-        submitted_failure_reason: Option<Vec<u8>>,
     },
 }
 
@@ -916,21 +907,22 @@ pub fn submit_on_chain_tool_result_for_walk_ptb(
                 )?;
             }
             PreparedOnchainToolResultSubmission::TerminalErrEval {
-                output,
-                failure_evidence_kind: _,
-                submitted_failure_reason: _,
+                reason,
+                failure_evidence_kind,
             } => {
-                let result = create_on_chain_tool_result_for_walk(
+                commit_on_chain_tool_terminal_err_eval_for_walk(
                     tx,
                     dag_arg,
                     execution_arg,
+                    tool_registry,
                     worksheet,
+                    reason,
+                    failure_evidence_kind,
                     leader_cap,
                     leader_registry,
                     walk_index,
                     expected_vertex,
                 )?;
-                finalize_onchain_tool_result_output(tx, result, worksheet, output)?;
                 lock_payment_state_for_tools(tx, lock_tool_gas_args, dag_arg, execution_arg)?;
             }
         }
@@ -1152,6 +1144,62 @@ fn commit_off_chain_tool_result_for_walk(
     Ok(())
 }
 
+fn failure_evidence_kind_arg(
+    tx: &mut move_boundary::NexusPtbBuilder<'_>,
+    kind: &FailureEvidenceKind,
+) -> anyhow::Result<sui::types::Argument> {
+    match kind {
+        FailureEvidenceKind::ToolEvidence => tx.call_target(
+            verifier_binding::failure_evidence_kind_tool_evidence_target,
+            vec![],
+        ),
+        FailureEvidenceKind::LeaderEvidence => tx.call_target(
+            verifier_binding::failure_evidence_kind_leader_evidence_target,
+            vec![],
+        ),
+    }
+}
+
+/// Commits a leader-authored terminal `_err_eval` for an on-chain tool walk directly, creating
+/// no `OnchainToolResult` (unlike `create_on_chain_tool_result_for_walk`/`commit_prepared_onchain_tool_execution`,
+/// which run the tool).
+#[allow(clippy::too_many_arguments)]
+fn commit_on_chain_tool_terminal_err_eval_for_walk(
+    tx: &mut move_boundary::NexusPtbBuilder<'_>,
+    dag: sui::types::Argument,
+    execution: sui::types::Argument,
+    tool_registry: sui::types::Argument,
+    worksheet: sui::types::Argument,
+    reason: &[u8],
+    failure_evidence_kind: &FailureEvidenceKind,
+    leader_cap: sui::types::Argument,
+    leader_registry: sui::types::Argument,
+    walk_index: u64,
+    expected_vertex: sui::types::Argument,
+) -> anyhow::Result<()> {
+    let walk_index = tx.arg(&walk_index)?;
+    let reason = tx.arg(&reason.to_vec())?;
+    let failure_evidence_kind = failure_evidence_kind_arg(tx, failure_evidence_kind)?;
+
+    tx.call_target(
+        execution_submission_binding::commit_on_chain_tool_terminal_err_eval_for_walk_target,
+        vec![
+            dag,
+            execution,
+            tool_registry,
+            worksheet,
+            reason,
+            failure_evidence_kind,
+            leader_cap,
+            leader_registry,
+            walk_index,
+            expected_vertex,
+        ],
+    )?;
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn release_vertex_authorization_for_onchain_walk(
     tx: &mut move_boundary::NexusPtbBuilder<'_>,
@@ -1244,40 +1292,6 @@ pub fn consume_on_chain_tool_result_for_walk(
     )?;
 
     Ok(())
-}
-
-fn finalize_onchain_tool_result_output(
-    tx: &mut move_boundary::NexusPtbBuilder<'_>,
-    result: sui::types::Argument,
-    worksheet: sui::types::Argument,
-    output: &PreparedOnchainToolOutput,
-) -> anyhow::Result<()> {
-    let output = prepare_tagged_tool_output(tx, output)?;
-    tx.call_target(
-        onchain_tool_result_binding::finalize_and_share_target,
-        vec![result, worksheet, output],
-    )?;
-    Ok(())
-}
-
-fn prepare_tagged_tool_output(
-    tx: &mut move_boundary::NexusPtbBuilder<'_>,
-    prepared: &PreparedOnchainToolOutput,
-) -> anyhow::Result<sui::types::Argument> {
-    let variant = tx.arg(&prepared.output_variant.as_bytes().to_vec())?;
-    let mut tagged_output = tx.call_target(tagged_output_binding::new_target, vec![variant])?;
-
-    for (output_port, dag_data) in &prepared.output_ports_data {
-        let port = tx.arg(&output_port.as_bytes().to_vec())?;
-        let value = tx.nexus_data(dag_data)?;
-        let typed_value = tx.call_target(data_binding::as_raw_target, vec![value])?;
-        tagged_output = tx.call_target(
-            tagged_output_binding::with_named_payload_target,
-            vec![tagged_output, port, typed_value],
-        )?;
-    }
-
-    Ok(tagged_output)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2399,6 +2413,43 @@ mod tests {
 
         assert!(lock_payment < execute);
         assert_eq!(execute, ptb.commands.len() - 1);
+    }
+
+    #[test]
+    fn terminal_err_eval_commits_without_creating_onchain_tool_result() {
+        let objects = nexus_objects();
+        let next_vertex = RuntimeVertex::plain("counter_increment");
+        let submission = PreparedOnchainToolResultSubmission::TerminalErrEval {
+            reason: b"boom".to_vec(),
+            failure_evidence_kind: FailureEvidenceKind::ToolEvidence,
+        };
+
+        let ptb = submit_on_chain_tool_result_for_walk_ptb(
+            &objects,
+            (addr("0x50"), 7),
+            (addr("0x60"), 8),
+            &object_ref("0x20", 1, 20),
+            &[],
+            0,
+            &next_vertex,
+            true,
+            &submission,
+        )
+        .unwrap();
+
+        move_call_index(
+            &ptb,
+            None,
+            "execution_submission",
+            "commit_on_chain_tool_terminal_err_eval_for_walk",
+        );
+
+        assert!(
+            move_calls(&ptb)
+                .iter()
+                .all(|call| call.function.as_str() != "create_on_chain_tool_result_for_walk"),
+            "TerminalErrEval must not create an OnchainToolResult"
+        );
     }
 
     #[test]

--- a/sdk/src/transactions/dag.rs
+++ b/sdk/src/transactions/dag.rs
@@ -1154,9 +1154,8 @@ fn failure_evidence_kind_arg(
     }
 }
 
-/// Commits a leader-authored terminal `_err_eval` for an on-chain tool walk directly, creating
-/// no `OnchainToolResult` (unlike `create_on_chain_tool_result_for_walk`/`commit_prepared_onchain_tool_execution`,
-/// which run the tool).
+/// Creates no `OnchainToolResult`, unlike `create_on_chain_tool_result_for_walk`/
+/// `commit_prepared_onchain_tool_execution`, which run the tool.
 #[allow(clippy::too_many_arguments)]
 fn commit_on_chain_tool_terminal_err_eval_for_walk(
     tx: &mut move_boundary::NexusPtbBuilder<'_>,

--- a/sdk/src/transactions/dag.rs
+++ b/sdk/src/transactions/dag.rs
@@ -122,12 +122,6 @@ fn begin_execution_inputs_arg(
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PreparedOnchainToolOutput {
-    pub output_variant: String,
-    pub output_ports_data: HashMap<String, NexusData>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
 struct RuntimeToolResultWorksheet {
     pub worksheet: sui::types::Argument,
     pub agent_registry: sui::types::Argument,


### PR DESCRIPTION
## What this does

Makes `TerminalErrEval` build a transaction that writes an on-chain tool's failure reason to the chain.

## Why

The code existed but nothing ever called it — and it would not have worked if anything had. It created an object on chain that nothing can read or clean up, so the failure reason would have been stranded there forever.

It now calls a new Move function that writes the reason directly, creating no such object.

## Changes

- `TerminalErrEval` now carries the reason text and who is at fault (the tool or the leader). Its old fields were unused.
- Deleted code that became unused, after checking nothing anywhere still referenced it.
- Regenerated the Move bindings so the new function is available.

## Testing

668 tests pass. Formatting and lint clean.

## Merge order

Merge this first. The nexus-next PR depends on it: Talus-Network/nexus#860

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYzfpCFmtRNxiLiK36WkJo
