### PR TITLE
fix(sdk): report object absence as a typed error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+### `nexus-sdk`
+
+#### Fixed
+
+- Object reads now report a definitive absence as `NexusError::ObjectNotFound` instead of an untyped RPC error, so callers can tell a missing object from an unreachable node.
+
 ## [`2.0.0`] - 2026-08-27
 
 ### `nexus-sdk`

--- a/sdk/src/nexus/crawler.rs
+++ b/sdk/src/nexus/crawler.rs
@@ -4,6 +4,7 @@
 use {
     crate::{
         move_bindings::sui_framework::{object::ID, table_vec::TableVec},
+        nexus::error::NexusError,
         sui::{self, traits::FieldMaskUtil},
     },
     anyhow::{anyhow, bail, Context as _},
@@ -1643,7 +1644,7 @@ impl Crawler {
     ) -> anyhow::Result<sui::grpc::Object> {
         self.fetch_optional_object(object_id, field_mask)
             .await?
-            .ok_or_else(|| anyhow!("Object '{object_id}' not found"))
+            .ok_or_else(|| anyhow::Error::new(NexusError::ObjectNotFound { object: object_id }))
     }
 
     async fn fetch_optional_object(

--- a/sdk/src/nexus/error.rs
+++ b/sdk/src/nexus/error.rs
@@ -265,9 +265,23 @@ pub enum NexusError {
         package: sui::types::Address,
         reason: String,
     },
+    /// The node answered definitively that the object does not exist.
+    #[error("Object '{object}' does not exist")]
+    ObjectNotFound { object: sui::types::Address },
     /// The SDK does not contain an adapter for the observed object state.
     #[error(transparent)]
     ClientUpgradeRequired(#[from] ClientUpgradeRequired),
+}
+
+impl NexusError {
+    /// Classifies an RPC-layer failure, keeping a definitive object absence
+    /// distinguishable from a failure to reach the node.
+    pub fn from_rpc(error: anyhow::Error) -> Self {
+        match error.downcast_ref::<Self>() {
+            Some(Self::ObjectNotFound { object }) => Self::ObjectNotFound { object: *object },
+            _ => Self::Rpc(error),
+        }
+    }
 }
 
 impl From<TransactionError> for NexusError {

--- a/sdk/src/nexus/state.rs
+++ b/sdk/src/nexus/state.rs
@@ -103,7 +103,9 @@ impl StateResolver {
     ///
     /// Returns [`NexusError::InvalidObjectState`] when the anchor does not have
     /// exactly one `Inner` field and one `Witness` field, or either value is not
-    /// a Move struct. Transport failures return [`NexusError::Rpc`].
+    /// a Move struct. A definitive absence returns
+    /// [`NexusError::ObjectNotFound`]; other transport failures return
+    /// [`NexusError::Rpc`].
     pub async fn observe(
         &self,
         object_id: sui::types::Address,
@@ -119,7 +121,7 @@ impl StateResolver {
                     sleep(STATE_OBSERVATION_RETRY_DELAY).await;
                     continue;
                 }
-                (Err(error), _) | (_, Err(error)) => return Err(NexusError::Rpc(error)),
+                (Err(error), _) | (_, Err(error)) => return Err(NexusError::from_rpc(error)),
             };
 
             match observed_state_from_metadata(object, fields) {
@@ -372,7 +374,7 @@ impl StateResolver {
             .crawler
             .get_object::<RuntimeAuthorityState>(root.object_id())
             .await
-            .map_err(NexusError::Rpc)?;
+            .map_err(NexusError::from_rpc)?;
         let invalid = |reason: String| NexusError::InvalidObjectState {
             object: root.object_id(),
             reason,
@@ -727,7 +729,7 @@ impl StateResolver {
             .crawler
             .get_object::<A>(object_id)
             .await
-            .map_err(NexusError::Rpc)?;
+            .map_err(NexusError::from_rpc)?;
         let inner = self
             .crawler
             .get_dynamic_field_value_by_id::<
@@ -735,7 +737,7 @@ impl StateResolver {
                 V,
             >(observed.inner.field_id)
             .await
-            .map_err(NexusError::Rpc)?;
+            .map_err(NexusError::from_rpc)?;
 
         Ok(crate::nexus::crawler::Response {
             object_id: anchor.object_id,
@@ -1251,6 +1253,42 @@ fn select_state_field(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn observation_separates_absence_from_an_unreachable_node() {
+        use crate::test_utils::sui_mocks;
+
+        let object_id = address("0x10");
+
+        let observe = |status: tonic::Status| async move {
+            let mut ledger = sui_mocks::grpc::MockLedgerService::new();
+            ledger
+                .expect_get_object()
+                .returning(move |_request| Err(status.clone()));
+
+            let rpc_url = sui_mocks::grpc::mock_server(sui_mocks::grpc::ServerMocks {
+                ledger_service_mock: Some(ledger),
+                ..Default::default()
+            });
+            let crawler = Crawler::new(Arc::new(
+                sui::grpc::client(&rpc_url).expect("mock Sui client builds"),
+            ));
+
+            StateResolver::new(Arc::new(crawler))
+                .observe(object_id)
+                .await
+                .expect_err("the mocked node always fails")
+        };
+
+        assert!(matches!(
+            observe(tonic::Status::not_found("missing")).await,
+            NexusError::ObjectNotFound { object } if object == object_id
+        ));
+        assert!(matches!(
+            observe(tonic::Status::unavailable("connection refused")).await,
+            NexusError::Rpc(_)
+        ));
+    }
 
     #[tokio::test]
     async fn observation_retries_incomplete_dynamic_field_metadata() {


### PR DESCRIPTION
`Crawler::fetch_object` turned a NOT_FOUND into `anyhow!("Object '{id}' not found")`, and callers wrapped that in `NexusError::Rpc`. An unreachable node, a malformed response and a genuinely missing object were all the same untyped value.

A consumer choosing between "retry forever" and "skip, the answer is final" therefore had to string-match the error text. nexus-api did, and got it wrong in the data-losing direction: an RPC endpoint answering 401 or 404 (tonic maps these to `Unauthenticated` / `Unimplemented`) classified as permanent, so its indexer advanced its cursor through the whole backlog and dropped it silently.

Absence now travels as `NexusError::ObjectNotFound`. `NexusError::from_rpc` un-flattens it at the four `StateResolver` sites that map crawler failures, so it survives `observe`, `resolve_and_load_inner`, `decode_inner` and the runtime-authority read instead of collapsing back into `Rpc`. Everything else stays `Rpc`.

`fetch_optional_object` still returns `Ok(None)` for NOT_FOUND, so existence checks are unchanged. `NexusError` stays exhaustive on purpose: downstream matches fail to compile until they decide what to do with the new variant.

+65/-6 across 4 files. `just sdk check|clippy|fmt-check|test` all pass. New test `observation_separates_absence_from_an_unreachable_node` asserts the distinction via `matches!`, no string comparison.

Breaking for anyone matching `NexusError` exhaustively.

The same commit cherry-picked onto the `v2.0.0-rc.final` tag is on `fix/typed-object-absence-rc-final`, for consumers pinned there.
